### PR TITLE
fix: Looping when not capturing lead

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -26,15 +26,6 @@ export interface ContactCaptureData extends QuestionAnsweringData, ResponseStrat
      * Default is PROGRAMMATIC
      */
     responses?: "GENERATIVE_AI" | "PROGRAMMATIC";
-
-    /**
-     * Contact information for the 
-     */
-    /* contactInformation?: {
-        email?: string;
-        phone?: string;
-        contactUrl?: string;
-    } */
 }
 
 export interface ContactCaptureBlueprint {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -163,8 +163,6 @@ export class ContactCaptureHandler extends QuestionAnsweringHandler<Content, Con
         }
 
         const ALWAYS_HANDLE: string[] = [
-            "KnowledgeAnswer",
-            "OCSearch",
             "InputUnknown",
             "Name",
             "NameOnly",
@@ -177,6 +175,12 @@ export class ContactCaptureHandler extends QuestionAnsweringHandler<Content, Con
             "AppointmentDate",
             "OptionSelect",
         ];
+
+        if (this?.data?.captureLead) {
+            // we add these if we are capturing the lead then we want to keep the
+            // user in this flow while still answering their question
+            ALWAYS_HANDLE.push(...["KnowledgeAnswer", "OCSearch"]);
+        }
 
         if (ALWAYS_HANDLE.includes(key)) {
             return true;
@@ -206,7 +210,6 @@ export class ContactCaptureHandler extends QuestionAnsweringHandler<Content, Con
 
         // Component Input
         this.handleMultiModalInput(request as ComponentRequest);
-
 
         /**
          * Set the Slots (captured data so far) on the Session Storage
@@ -259,10 +262,10 @@ export class ContactCaptureHandler extends QuestionAnsweringHandler<Content, Con
             log().warn('captureLeads is not set, currently defaulting to false which means it will not capture lead data.')
         }
 
+        // Determine our strategy
         const strategy = new ResponseStrategySelector().getStrategy();
-
+        // Get the response
         const response = await strategy.getResponse(this, request, context);
-
         // Compile and respond
         const compiled = compileResponse(response, request, context);
         // Change turnsToLive to 1

--- a/src/strategies/ProgrammaticResponseStrategy.ts
+++ b/src/strategies/ProgrammaticResponseStrategy.ts
@@ -19,7 +19,7 @@ import {
 
 import * as Constants from "../constants";
 import { ContactDataType, CaptureRuntimeData } from "../data";
-import { lookingForHelp, newLeadGenerationData, } from "../utils";
+import { concatenateAside, lookingForHelp, newLeadGenerationData, } from "../utils";
 import { ContactCaptureHandler } from "../handler";
 import { GooglePlacesService, PlacesService } from "../services";
 
@@ -39,11 +39,11 @@ export class ProgrammaticResponseStrategy implements ResponseStrategy {
         let response: Response;
         const responses = findValueForKey(handler.intentId, handler.content);
 
+        // if we are NOT capturing leads
         if (!handler.data.captureLead) {
-
             // First find response for not sending leads
             const noCaptureResponse = getResponseByTag(responses, Constants.CONTACT_CAPTURE_NO_LEAD_CAPTURE_CONTENT);
-
+            // if we have it, set it as the response
             if (noCaptureResponse) {
                 response = noCaptureResponse;
             } else {
@@ -91,6 +91,8 @@ export class ProgrammaticResponseStrategy implements ResponseStrategy {
                     }
                 }
             }
+
+            response = concatenateAside(response, asideResponse);
 
             return response;
         }
@@ -193,10 +195,7 @@ export class ProgrammaticResponseStrategy implements ResponseStrategy {
                 log().debug(`We have an aside response, concatenating with found response.`);
                 log().debug(asideResponse);
                 // I think we want to use the reprompt here.
-                const reprompt = concatResponseOutput({ displayText: "\n \n \n", ssml: "" }, toResponseOutput(response.reprompt));
-                response.outputSpeech = concatResponseOutput(toResponseOutput(asideResponse.outputSpeech), toResponseOutput(reprompt), { delimiter: "\n\n" });
-                response.reprompt = response.reprompt;
-                response.displays = asideResponse.displays;
+                response = concatenateAside(response, asideResponse);
             } else if (repeat) {
                 // Give them the reprompt on a repeat
                 response.outputSpeech = response.reprompt;


### PR DESCRIPTION
New captureLead:false was causing a looping behavior where we would keep returning the same content.