### PR TITLE
fix: resolved two code paths for getting the form response

### DIFF
--- a/src/strategies/FormResponseStrategy.ts
+++ b/src/strategies/FormResponseStrategy.ts
@@ -140,7 +140,7 @@ export class FormResponseStrategy implements ResponseStrategy {
 
         if (!isAbandoned) {
             const data: FormActionResponseData = request.attributes?.data as FormActionResponseData;
-            const stepFromData = getStepFromData(handler.data, data.form, data.step);
+            const stepFromData = getStepFromData(handler.data, { formName: data.form, fallback: { enablePreferredTime, service } }, data.step);
 
             // Send the requested form
             if (data.followupForm) {

--- a/src/strategies/utils/__test__/forms.test.ts
+++ b/src/strategies/utils/__test__/forms.test.ts
@@ -2,7 +2,7 @@
 import * as chai from "chai";
 import * as sinonChai from "sinon-chai";
 
-import { FormChipsInput, MultistepForm } from "stentor-models";
+import { FormChipsInput } from "stentor-models";
 
 import { getContactFormFallback } from "../forms";
 
@@ -12,86 +12,68 @@ const expect = chai.expect;
 describe(`#${getContactFormFallback.name}()`, () => {
     describe("when passed empty props", () => {
         it("returns as expected", () => {
-            const response = getContactFormFallback({});
-            expect(response).to.exist;
-            expect(response?.displays?.length).to.equal(1);
+            const form = getContactFormFallback({});
+            expect(form).to.exist;
 
-            if (response?.displays) {
+            expect(form.steps).to.have.length(2);
 
-                const form: MultistepForm = response?.displays[0] as any as MultistepForm;;
-                expect(form).to.exist;
+            const step = form.steps[0];
+            expect(step).to.exist;
+            // name, phone, message
+            expect(step.fields).to.have.length(3);
 
-                expect(form.steps).to.have.length(2);
-
-                const step = form.steps[0];
-                expect(step).to.exist;
-                // name, phone, message
-                expect(step.fields).to.have.length(3);
-            }
         });
     });
     describe("when passed fallback props", () => {
         it("returns as expected", () => {
-            const response = getContactFormFallback({ fallback: { enablePreferredTime: true, service: "schedule_maintenance" } });
-            expect(response).to.exist;
-            expect(response?.displays?.length).to.equal(1);
+            const form = getContactFormFallback({ fallback: { enablePreferredTime: true, service: "schedule_maintenance" } });
 
-            if (response?.displays) {
+            expect(form).to.exist;
+            expect(form.steps).to.have.length(5);
 
-                const form: MultistepForm = response?.displays[0] as any as MultistepForm;
+            // console.log(JSON.stringify(form.steps, null, 2));
+            const step = form.steps[0];
+            expect(step).to.exist;
+            // service field and message field
+            expect(step.fields).to.have.length(2);
+
+            // items, should be 3
+            const chipItem = step.fields[0];
+            expect(chipItem.type).to.equal("CHIPS");
+            if (chipItem.type === "CHIPS") {
+                const items = (chipItem as FormChipsInput).items;
+                expect(items).to.have.length(4);
+                const schedule = items[0];
+                expect(schedule.selected).to.be.true;
+                expect(schedule.id).to.equal("schedule_maintenance");
+                expect(schedule.label).to.equal("Schedule Maintenance");
+            }
+
+        });
+        describe("with an existing service", () => {
+            it("returns as expected", () => {
+                const form = getContactFormFallback({ fallback: { enablePreferredTime: true, service: "contact_us" } });
+
+
                 expect(form).to.exist;
                 expect(form.steps).to.have.length(5);
 
                 // console.log(JSON.stringify(form.steps, null, 2));
+
                 const step = form.steps[0];
                 expect(step).to.exist;
                 // service field and message field
                 expect(step.fields).to.have.length(2);
 
-                // items, should be 3
                 const chipItem = step.fields[0];
                 expect(chipItem.type).to.equal("CHIPS");
                 if (chipItem.type === "CHIPS") {
                     const items = (chipItem as FormChipsInput).items;
-                    expect(items).to.have.length(4);
-                    const schedule = items[0];
+                    expect(items).to.have.length(3);
+                    const schedule = items[2];
                     expect(schedule.selected).to.be.true;
-                    expect(schedule.id).to.equal("schedule_maintenance");
-                    expect(schedule.label).to.equal("Schedule Maintenance");
-                }
-            }
-        });
-        describe("with an existing service", () => {
-            it("returns as expected", () => {
-                const response = getContactFormFallback({ fallback: { enablePreferredTime: true, service: "contact_us" } });
-                expect(response).to.exist;
-                // only two steps
-                expect(response?.displays?.length).to.equal(1);
-
-                if (response?.displays) {
-
-                    const form: MultistepForm = response?.displays[0] as any as MultistepForm;
-
-                    expect(form).to.exist;
-                    expect(form.steps).to.have.length(5);
-
-                    // console.log(JSON.stringify(form.steps, null, 2));
-
-                    const step = form.steps[0];
-                    expect(step).to.exist;
-                    // service field and message field
-                    expect(step.fields).to.have.length(2);
-
-                    const chipItem = step.fields[0];
-                    expect(chipItem.type).to.equal("CHIPS");
-                    if (chipItem.type === "CHIPS") {
-                        const items = (chipItem as FormChipsInput).items;
-                        expect(items).to.have.length(3);
-                        const schedule = items[2];
-                        expect(schedule.selected).to.be.true;
-                        expect(schedule.id).to.equal("contact_us");
-                        expect(schedule.label).to.equal("Contact Us");
-                    }
+                    expect(schedule.id).to.equal("contact_us");
+                    expect(schedule.label).to.equal("Contact Us");
                 }
             });
         });


### PR DESCRIPTION
We had two code paths when attempting to resolve which form is being used, either a custom one or a default one.