### PR TITLE
feat: pass TrustedForm cert URL through as an extra

### DIFF
--- a/src/__test__/handler.test.ts
+++ b/src/__test__/handler.test.ts
@@ -375,6 +375,70 @@ describe(`${ContactCaptureHandler.name}`, () => {
                 expect(extras).to.not.have.property("msclkid");
             });
         });
+        describe("for a request with TrustedForm slots", () => {
+            it("adds TrustedForm cert and ping URLs to extras", () => {
+                const request = new IntentRequestBuilder().build();
+
+                const crmService = new MockCRM();
+                const sendSpy = sandbox.spy(crmService, "send");
+
+                const slots = {
+                    xxTrustedFormCertUrl: {
+                        name: "xxTrustedFormCertUrl",
+                        value: "https://cert.trustedform.com/abc123",
+                    },
+                    xxTrustedFormPingUrl: {
+                        name: "xxTrustedFormPingUrl",
+                        value: "https://ping.trustedform.com/abc123",
+                    },
+                };
+
+                ContactCaptureHandler.sendLead(slots, {}, { data: [] }, [], crmService, request, new MockErrorService());
+
+                expect(sendSpy).to.have.been.calledOnce;
+                const extras = sendSpy.getCall(0).args[1];
+
+                expect(extras).to.have.property("xxTrustedFormCertUrl", "https://cert.trustedform.com/abc123");
+                expect(extras).to.have.property("xxTrustedFormPingUrl", "https://ping.trustedform.com/abc123");
+            });
+
+            it("only adds TrustedForm URLs that are present in slots", () => {
+                const request = new IntentRequestBuilder().build();
+
+                const crmService = new MockCRM();
+                const sendSpy = sandbox.spy(crmService, "send");
+
+                const slots = {
+                    xxTrustedFormCertUrl: {
+                        name: "xxTrustedFormCertUrl",
+                        value: "https://cert.trustedform.com/abc123",
+                    },
+                };
+
+                ContactCaptureHandler.sendLead(slots, {}, { data: [] }, [], crmService, request, new MockErrorService());
+
+                expect(sendSpy).to.have.been.calledOnce;
+                const extras = sendSpy.getCall(0).args[1];
+
+                expect(extras).to.have.property("xxTrustedFormCertUrl", "https://cert.trustedform.com/abc123");
+                expect(extras).to.not.have.property("xxTrustedFormPingUrl");
+            });
+
+            it("does not add TrustedForm URLs when slots are absent", () => {
+                const request = new IntentRequestBuilder().build();
+
+                const crmService = new MockCRM();
+                const sendSpy = sandbox.spy(crmService, "send");
+
+                ContactCaptureHandler.sendLead({}, {}, { data: [] }, [], crmService, request, new MockErrorService());
+
+                expect(sendSpy).to.have.been.calledOnce;
+                const extras = sendSpy.getCall(0).args[1];
+
+                expect(extras).to.not.have.property("xxTrustedFormCertUrl");
+                expect(extras).to.not.have.property("xxTrustedFormPingUrl");
+            });
+        });
     });
     describe(`#${ContactCaptureHandler.prototype.handleRequest.name}()`, () => {
         describe("with captureLead set to true", () => {

--- a/src/__test__/handler.test.ts
+++ b/src/__test__/handler.test.ts
@@ -27,6 +27,8 @@ import {
     CONTACT_CAPTURE_LIST,
     CONTACT_CAPTURE_SENT,
     CONTACT_CAPTURE_SLOTS,
+    TRUSTED_FORM_CERT_URL_SLOT,
+    TRUSTED_FORM_PING_URL_SLOT,
 } from "../constants";
 import { DetailParams, Place, PlacesService, SearchParams } from "../services";
 
@@ -383,12 +385,12 @@ describe(`${ContactCaptureHandler.name}`, () => {
                 const sendSpy = sandbox.spy(crmService, "send");
 
                 const slots = {
-                    xxTrustedFormCertUrl: {
-                        name: "xxTrustedFormCertUrl",
+                    [TRUSTED_FORM_CERT_URL_SLOT]: {
+                        name: TRUSTED_FORM_CERT_URL_SLOT,
                         value: "https://cert.trustedform.com/abc123",
                     },
-                    xxTrustedFormPingUrl: {
-                        name: "xxTrustedFormPingUrl",
+                    [TRUSTED_FORM_PING_URL_SLOT]: {
+                        name: TRUSTED_FORM_PING_URL_SLOT,
                         value: "https://ping.trustedform.com/abc123",
                     },
                 };
@@ -398,8 +400,28 @@ describe(`${ContactCaptureHandler.name}`, () => {
                 expect(sendSpy).to.have.been.calledOnce;
                 const extras = sendSpy.getCall(0).args[1];
 
-                expect(extras).to.have.property("xxTrustedFormCertUrl", "https://cert.trustedform.com/abc123");
-                expect(extras).to.have.property("xxTrustedFormPingUrl", "https://ping.trustedform.com/abc123");
+                expect(extras).to.have.property(TRUSTED_FORM_CERT_URL_SLOT, "https://cert.trustedform.com/abc123");
+                expect(extras).to.have.property(TRUSTED_FORM_PING_URL_SLOT, "https://ping.trustedform.com/abc123");
+            });
+
+            it("preserves the xx-prefixed key names in extras", () => {
+                const request = new IntentRequestBuilder().build();
+
+                const crmService = new MockCRM();
+                const sendSpy = sandbox.spy(crmService, "send");
+
+                const slots = {
+                    [TRUSTED_FORM_CERT_URL_SLOT]: {
+                        name: TRUSTED_FORM_CERT_URL_SLOT,
+                        value: "https://cert.trustedform.com/abc123",
+                    },
+                };
+
+                ContactCaptureHandler.sendLead(slots, {}, { data: [] }, [], crmService, request, new MockErrorService());
+
+                const extras = sendSpy.getCall(0).args[1];
+                expect(Object.keys(extras)).to.include("xxTrustedFormCertUrl");
+                expect(Object.keys(extras)).to.not.include("trustedFormCertUrl");
             });
 
             it("only adds TrustedForm URLs that are present in slots", () => {
@@ -409,8 +431,8 @@ describe(`${ContactCaptureHandler.name}`, () => {
                 const sendSpy = sandbox.spy(crmService, "send");
 
                 const slots = {
-                    xxTrustedFormCertUrl: {
-                        name: "xxTrustedFormCertUrl",
+                    [TRUSTED_FORM_CERT_URL_SLOT]: {
+                        name: TRUSTED_FORM_CERT_URL_SLOT,
                         value: "https://cert.trustedform.com/abc123",
                     },
                 };
@@ -420,8 +442,8 @@ describe(`${ContactCaptureHandler.name}`, () => {
                 expect(sendSpy).to.have.been.calledOnce;
                 const extras = sendSpy.getCall(0).args[1];
 
-                expect(extras).to.have.property("xxTrustedFormCertUrl", "https://cert.trustedform.com/abc123");
-                expect(extras).to.not.have.property("xxTrustedFormPingUrl");
+                expect(extras).to.have.property(TRUSTED_FORM_CERT_URL_SLOT, "https://cert.trustedform.com/abc123");
+                expect(extras).to.not.have.property(TRUSTED_FORM_PING_URL_SLOT);
             });
 
             it("does not add TrustedForm URLs when slots are absent", () => {
@@ -435,8 +457,34 @@ describe(`${ContactCaptureHandler.name}`, () => {
                 expect(sendSpy).to.have.been.calledOnce;
                 const extras = sendSpy.getCall(0).args[1];
 
-                expect(extras).to.not.have.property("xxTrustedFormCertUrl");
-                expect(extras).to.not.have.property("xxTrustedFormPingUrl");
+                expect(extras).to.not.have.property(TRUSTED_FORM_CERT_URL_SLOT);
+                expect(extras).to.not.have.property(TRUSTED_FORM_PING_URL_SLOT);
+            });
+
+            it("does not add TrustedForm URLs when slot value is an empty string", () => {
+                const request = new IntentRequestBuilder().build();
+
+                const crmService = new MockCRM();
+                const sendSpy = sandbox.spy(crmService, "send");
+
+                const slots = {
+                    [TRUSTED_FORM_CERT_URL_SLOT]: {
+                        name: TRUSTED_FORM_CERT_URL_SLOT,
+                        value: "",
+                    },
+                    [TRUSTED_FORM_PING_URL_SLOT]: {
+                        name: TRUSTED_FORM_PING_URL_SLOT,
+                        value: "",
+                    },
+                };
+
+                ContactCaptureHandler.sendLead(slots, {}, { data: [] }, [], crmService, request, new MockErrorService());
+
+                expect(sendSpy).to.have.been.calledOnce;
+                const extras = sendSpy.getCall(0).args[1];
+
+                expect(extras).to.not.have.property(TRUSTED_FORM_CERT_URL_SLOT);
+                expect(extras).to.not.have.property(TRUSTED_FORM_PING_URL_SLOT);
             });
         });
     });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -83,7 +83,9 @@ export const CONTACT_CAPTURE_INTENT = CONTACT_CAPTURE_PREFIX;
 
 export const CONTACT_CAPTURE_HANDLER_TYPE = "ContactCaptureHandlerType";
 
-
+// TrustedForm slot names (from form submission)
+export const TRUSTED_FORM_CERT_URL_SLOT = "xxTrustedFormCertUrl";
+export const TRUSTED_FORM_PING_URL_SLOT = "xxTrustedFormPingUrl";
 
 export const DEFAULT_RESPONSES: Response[] = [
     {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -202,6 +202,14 @@ export class ContactCaptureHandler extends QuestionAnsweringHandler<Content, Con
             }
         }
 
+        // TrustedForm certificate URLs (from form submission slots)
+        if (slots.xxTrustedFormCertUrl?.value) {
+            extras.xxTrustedFormCertUrl = requestSlotValueToString(slots.xxTrustedFormCertUrl.value);
+        }
+        if (slots.xxTrustedFormPingUrl?.value) {
+            extras.xxTrustedFormPingUrl = requestSlotValueToString(slots.xxTrustedFormPingUrl.value);
+        }
+
         log().debug(`Sending lead to FSM/CRM:`);
         log().debug(`===\n${JSON.stringify(externalLead, null, 2)}\n===`);
 

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -203,11 +203,11 @@ export class ContactCaptureHandler extends QuestionAnsweringHandler<Content, Con
         }
 
         // TrustedForm certificate URLs (from form submission slots)
-        if (slots.xxTrustedFormCertUrl?.value) {
-            extras.xxTrustedFormCertUrl = requestSlotValueToString(slots.xxTrustedFormCertUrl.value);
+        if (slots[Constants.TRUSTED_FORM_CERT_URL_SLOT]?.value) {
+            extras[Constants.TRUSTED_FORM_CERT_URL_SLOT] = requestSlotValueToString(slots[Constants.TRUSTED_FORM_CERT_URL_SLOT].value);
         }
-        if (slots.xxTrustedFormPingUrl?.value) {
-            extras.xxTrustedFormPingUrl = requestSlotValueToString(slots.xxTrustedFormPingUrl.value);
+        if (slots[Constants.TRUSTED_FORM_PING_URL_SLOT]?.value) {
+            extras[Constants.TRUSTED_FORM_PING_URL_SLOT] = requestSlotValueToString(slots[Constants.TRUSTED_FORM_PING_URL_SLOT].value);
         }
 
         log().debug(`Sending lead to FSM/CRM:`);


### PR DESCRIPTION
Pass TrustedForm cert and ping URLs from form submission slots through as extras in `sendLead()`, enabling downstream integrations (email, Boberdoo) to access them.

Closes #643

Generated with [Claude Code](https://claude.ai/code)