### PR TITLE
Support COMPANY/ORGANIZATION types and type-based matching in form fields

### DIFF
--- a/src/strategies/utils/__test__/forms.test.ts
+++ b/src/strategies/utils/__test__/forms.test.ts
@@ -3824,7 +3824,39 @@ describe(`#${getContactFormFallback.name}()`, () => {
             expect(orgField).to.exist;
             expect(orgField.label).to.equal("Organization");
             expect(orgField.placeholder).to.equal("Your organization name");
+            expect(orgField.mandatory).to.be.false;
             expect(orgField.maxLength).to.equal(100);
+        });
+
+        it("renders a required organization field when required is true", () => {
+            const form = getContactFormFallback(
+                {
+                    capture: {
+                        data: [
+                            {
+                                slotName: "full_name",
+                                active: true,
+                                type: "FULL_NAME" as const,
+                                questionContentKey: "NameQuestionContent",
+                                required: true,
+                            },
+                            {
+                                slotName: "organization",
+                                active: true,
+                                type: "ORGANIZATION" as const,
+                                questionContentKey: "OrgQuestionContent",
+                                required: true,
+                            },
+                        ],
+                    },
+                },
+                {},
+            );
+
+            const contactStep = form.steps[0];
+            const orgField = contactStep.fields.find((f) => f.name === "organization") as FormTextInput;
+            expect(orgField).to.exist;
+            expect(orgField.mandatory).to.be.true;
         });
     });
 

--- a/src/strategies/utils/__test__/forms.test.ts
+++ b/src/strategies/utils/__test__/forms.test.ts
@@ -4164,5 +4164,105 @@ describe(`#${getContactFormFallback.name}()`, () => {
             expect(messageField).to.exist;
             expect(messageField.mandatory).to.be.false;
         });
+
+        it("matches FULL_NAME type with non-standard slotName", () => {
+            const form = getContactFormFallback(
+                {
+                    capture: {
+                        data: [
+                            {
+                                slotName: "customer_name",
+                                active: true,
+                                type: "FULL_NAME" as const,
+                                questionContentKey: "NameQuestionContent",
+                                required: true,
+                            },
+                        ],
+                    },
+                },
+                {},
+            );
+
+            const contactStep = form.steps[0];
+            const nameField = contactStep.fields.find((f) => f.name === "full_name") as FormTextInput;
+            expect(nameField).to.exist;
+            expect(nameField.label).to.equal("Name");
+            expect(nameField.placeholder).to.equal("Your full name");
+            expect(nameField.mandatory).to.be.true;
+        });
+
+        it("matches FIRST_NAME and LAST_NAME types with non-standard slotNames", () => {
+            const form = getContactFormFallback(
+                {
+                    capture: {
+                        data: [
+                            {
+                                slotName: "given_name",
+                                active: true,
+                                type: "FIRST_NAME" as const,
+                                questionContentKey: "FirstNameQuestionContent",
+                                required: true,
+                            },
+                            {
+                                slotName: "surname",
+                                active: true,
+                                type: "LAST_NAME" as const,
+                                questionContentKey: "LastNameQuestionContent",
+                                required: true,
+                            },
+                        ],
+                    },
+                },
+                {},
+            );
+
+            const contactStep = form.steps[0];
+            const firstNameField = contactStep.fields.find((f) => f.name === "first_name") as FormTextInput;
+            expect(firstNameField).to.exist;
+            expect(firstNameField.label).to.equal("First Name");
+            expect(firstNameField.mandatory).to.be.true;
+
+            const lastNameField = contactStep.fields.find((f) => f.name === "last_name") as FormTextInput;
+            expect(lastNameField).to.exist;
+            expect(lastNameField.label).to.equal("Last Name");
+            expect(lastNameField.mandatory).to.be.true;
+        });
+
+        it("matches SELECTION type with non-standard slotName", () => {
+            const form = getContactFormFallback(
+                {
+                    capture: {
+                        data: [
+                            {
+                                slotName: "full_name",
+                                active: true,
+                                type: "FULL_NAME" as const,
+                                questionContentKey: "NameQuestionContent",
+                                required: true,
+                            },
+                            {
+                                slotName: "service_type",
+                                active: true,
+                                type: "SELECTION" as const,
+                                questionContentKey: "SelectionQuestionContent",
+                                required: true,
+                                enums: ["Plumbing", "Electrical"],
+                                title: "What service do you need?",
+                            },
+                        ],
+                    },
+                },
+                { enablePreferredTime: true },
+            );
+
+            const contactStep = form.steps.find((s) => s.name === "contact_info")!;
+            const selectionField = contactStep.fields.find((f) => f.name === "selection") as FormChipsInput;
+            expect(selectionField).to.exist;
+            expect(selectionField.type).to.equal("CHIPS");
+            expect(selectionField.title).to.equal("What service do you need?");
+            expect(selectionField.items).to.have.length(2);
+            expect(selectionField.items[0].label).to.equal("Plumbing");
+            expect(selectionField.items[1].label).to.equal("Electrical");
+        });
     });
 });

--- a/src/strategies/utils/__test__/forms.test.ts
+++ b/src/strategies/utils/__test__/forms.test.ts
@@ -3946,6 +3946,59 @@ describe(`#${getContactFormFallback.name}()`, () => {
             expect(orgIdx).to.be.greaterThan(companyIdx);
             expect(messageIdx).to.be.greaterThan(orgIdx);
         });
+
+        it("renders company and organization in the scheduling form", () => {
+            const form = getContactFormFallback(
+                {
+                    capture: {
+                        data: [
+                            {
+                                slotName: "full_name",
+                                active: true,
+                                type: "FULL_NAME" as const,
+                                questionContentKey: "NameQuestionContent",
+                                required: true,
+                            },
+                            {
+                                slotName: "phone",
+                                active: true,
+                                type: "PHONE" as const,
+                                questionContentKey: "PhoneQuestionContent",
+                                required: true,
+                            },
+                            {
+                                slotName: "company",
+                                active: true,
+                                type: "COMPANY" as const,
+                                questionContentKey: "CompanyQuestionContent",
+                                required: false,
+                            },
+                            {
+                                slotName: "organization",
+                                active: true,
+                                type: "ORGANIZATION" as const,
+                                questionContentKey: "OrgQuestionContent",
+                                required: true,
+                            },
+                        ],
+                    },
+                },
+                { enablePreferredTime: true },
+            );
+
+            const contactStep = form.steps.find((s) => s.name === "contact_info")!;
+            expect(contactStep).to.exist;
+
+            const companyField = contactStep.fields.find((f) => f.name === "company") as FormTextInput;
+            expect(companyField).to.exist;
+            expect(companyField.label).to.equal("Company");
+            expect(companyField.mandatory).to.be.false;
+
+            const orgField = contactStep.fields.find((f) => f.name === "organization") as FormTextInput;
+            expect(orgField).to.exist;
+            expect(orgField.label).to.equal("Organization");
+            expect(orgField.mandatory).to.be.true;
+        });
     });
 
     describe("type-based fallback matching", () => {
@@ -3980,6 +4033,39 @@ describe(`#${getContactFormFallback.name}()`, () => {
             expect(zipField.format).to.equal("ZIP_CODE");
             expect(zipField.label).to.equal("Zip Code");
             expect(zipField.maxLength).to.equal(10);
+        });
+
+        it("normalizes name and label to 'address'/'Address' when type is 'ADDRESS' with non-standard slotName", () => {
+            const form = getContactFormFallback(
+                {
+                    capture: {
+                        data: [
+                            {
+                                slotName: "full_name",
+                                active: true,
+                                type: "FULL_NAME" as const,
+                                questionContentKey: "NameQuestionContent",
+                                required: true,
+                            },
+                            {
+                                slotName: "street_address",
+                                active: true,
+                                type: "ADDRESS" as const,
+                                questionContentKey: "AddressQuestionContent",
+                                required: true,
+                            },
+                        ],
+                    },
+                },
+                { enablePreferredTime: true },
+            );
+
+            const contactStep = form.steps.find((s) => s.name === "contact_info")!;
+            const addressField = contactStep.fields.find((f) => f.name === "address") as FormTextInput;
+            expect(addressField).to.exist;
+            expect(addressField.label).to.equal("Address");
+            expect((addressField as any).format).to.equal("ADDRESS");
+            expect(addressField.maxLength).to.equal(500);
         });
 
         it("normalizes name to 'phone' and includes in contact-only form with non-standard slotName", () => {

--- a/src/strategies/utils/__test__/forms.test.ts
+++ b/src/strategies/utils/__test__/forms.test.ts
@@ -3750,6 +3750,8 @@ describe(`#${getContactFormFallback.name}()`, () => {
                 {},
             );
 
+            // Verify this is the contact-only form variant
+            expect(form.name).to.equal("contact_us_only");
             const contactStep = form.steps[0];
             const companyField = contactStep.fields.find((f) => f.name === "company") as FormTextInput;
             expect(companyField).to.exist;
@@ -3815,6 +3817,8 @@ describe(`#${getContactFormFallback.name}()`, () => {
                 {},
             );
 
+            // Verify this is the contact-only form variant
+            expect(form.name).to.equal("contact_us_only");
             const contactStep = form.steps[0];
             const orgField = contactStep.fields.find((f) => f.name === "organization") as FormTextInput;
             expect(orgField).to.exist;
@@ -3854,6 +3858,7 @@ describe(`#${getContactFormFallback.name}()`, () => {
             const zipField = contactStep.fields.find((f) => f.name === "zip") as FormTextInput;
             expect(zipField).to.exist;
             expect(zipField.format).to.equal("ZIP_CODE");
+            expect(zipField.label).to.equal("Zip Code");
             expect(zipField.maxLength).to.equal(10);
         });
 
@@ -3886,6 +3891,7 @@ describe(`#${getContactFormFallback.name}()`, () => {
             const phoneField = contactStep.fields.find((f) => f.name === "phone") as FormTextInput;
             expect(phoneField).to.exist;
             expect(phoneField.format).to.equal("PHONE");
+            expect(phoneField.label).to.equal("Phone");
             expect(phoneField.maxLength).to.equal(15);
         });
 
@@ -3918,6 +3924,7 @@ describe(`#${getContactFormFallback.name}()`, () => {
             const emailField = contactStep.fields.find((f) => f.name === "email") as FormTextInput;
             expect(emailField).to.exist;
             expect(emailField.format).to.equal("EMAIL");
+            expect(emailField.label).to.equal("Email");
             expect(emailField.maxLength).to.equal(254);
         });
 

--- a/src/strategies/utils/__test__/forms.test.ts
+++ b/src/strategies/utils/__test__/forms.test.ts
@@ -3723,4 +3723,170 @@ describe(`#${getContactFormFallback.name}()`, () => {
             expect((emailField as any).mandatoryGroup).to.be.undefined;
         });
     });
+
+    describe("COMPANY and ORGANIZATION fields", () => {
+        it("renders a company field when slotName is 'company'", () => {
+            const form = getContactFormFallback(
+                {
+                    capture: {
+                        data: [
+                            {
+                                slotName: "full_name",
+                                active: true,
+                                type: "FULL_NAME" as const,
+                                questionContentKey: "NameQuestionContent",
+                                required: true,
+                            },
+                            {
+                                slotName: "company",
+                                active: true,
+                                type: "COMPANY" as const,
+                                questionContentKey: "CompanyQuestionContent",
+                                required: false,
+                            },
+                        ],
+                    },
+                },
+                {},
+            );
+
+            const contactStep = form.steps[0];
+            const companyField = contactStep.fields.find((f) => f.name === "company") as FormTextInput;
+            expect(companyField).to.exist;
+            expect(companyField.label).to.equal("Company");
+            expect(companyField.placeholder).to.equal("Your company name");
+            expect(companyField.maxLength).to.equal(100);
+        });
+
+        it("renders a company field when type is 'COMPANY' regardless of slotName", () => {
+            const form = getContactFormFallback(
+                {
+                    capture: {
+                        data: [
+                            {
+                                slotName: "full_name",
+                                active: true,
+                                type: "FULL_NAME" as const,
+                                questionContentKey: "NameQuestionContent",
+                                required: true,
+                            },
+                            {
+                                slotName: "business_name",
+                                active: true,
+                                type: "COMPANY" as const,
+                                questionContentKey: "CompanyQuestionContent",
+                                required: true,
+                            },
+                        ],
+                    },
+                },
+                {},
+            );
+
+            const contactStep = form.steps[0];
+            const companyField = contactStep.fields.find((f) => f.name === "company") as FormTextInput;
+            expect(companyField).to.exist;
+            expect(companyField.label).to.equal("Company");
+            expect(companyField.mandatory).to.be.true;
+        });
+
+        it("renders an organization field when type is 'ORGANIZATION'", () => {
+            const form = getContactFormFallback(
+                {
+                    capture: {
+                        data: [
+                            {
+                                slotName: "full_name",
+                                active: true,
+                                type: "FULL_NAME" as const,
+                                questionContentKey: "NameQuestionContent",
+                                required: true,
+                            },
+                            {
+                                slotName: "org",
+                                active: true,
+                                type: "ORGANIZATION" as const,
+                                questionContentKey: "OrgQuestionContent",
+                                required: false,
+                            },
+                        ],
+                    },
+                },
+                {},
+            );
+
+            const contactStep = form.steps[0];
+            const orgField = contactStep.fields.find((f) => f.name === "organization") as FormTextInput;
+            expect(orgField).to.exist;
+            expect(orgField.label).to.equal("Organization");
+            expect(orgField.placeholder).to.equal("Your organization name");
+            expect(orgField.maxLength).to.equal(100);
+        });
+    });
+
+    describe("type-based fallback matching", () => {
+        it("renders a zip field when type is 'ZIP' even with non-standard slotName", () => {
+            const form = getContactFormFallback(
+                {
+                    capture: {
+                        data: [
+                            {
+                                slotName: "full_name",
+                                active: true,
+                                type: "FULL_NAME" as const,
+                                questionContentKey: "NameQuestionContent",
+                                required: true,
+                            },
+                            {
+                                slotName: "zip_code",
+                                active: true,
+                                type: "ZIP" as const,
+                                questionContentKey: "ZipQuestionContent",
+                                required: true,
+                            },
+                        ],
+                    },
+                },
+                { enablePreferredTime: true },
+            );
+
+            const contactStep = form.steps.find((s) => s.name === "contact_info")!;
+            const zipField = contactStep.fields.find((f) => f.name === "zip_code") as FormTextInput;
+            expect(zipField).to.exist;
+            expect(zipField.format).to.equal("ZIP_CODE");
+            expect(zipField.maxLength).to.equal(10);
+        });
+
+        it("renders a phone field when type is 'PHONE' even with non-standard slotName", () => {
+            const form = getContactFormFallback(
+                {
+                    capture: {
+                        data: [
+                            {
+                                slotName: "full_name",
+                                active: true,
+                                type: "FULL_NAME" as const,
+                                questionContentKey: "NameQuestionContent",
+                                required: true,
+                            },
+                            {
+                                slotName: "phone_number",
+                                active: true,
+                                type: "PHONE" as const,
+                                questionContentKey: "PhoneQuestionContent",
+                                required: false,
+                            },
+                        ],
+                    },
+                },
+                { enablePreferredTime: true },
+            );
+
+            const contactStep = form.steps.find((s) => s.name === "contact_info")!;
+            const phoneField = contactStep.fields.find((f) => f.name === "phone_number") as FormTextInput;
+            expect(phoneField).to.exist;
+            expect(phoneField.format).to.equal("PHONE");
+            expect(phoneField.maxLength).to.equal(15);
+        });
+    });
 });

--- a/src/strategies/utils/__test__/forms.test.ts
+++ b/src/strategies/utils/__test__/forms.test.ts
@@ -3825,7 +3825,7 @@ describe(`#${getContactFormFallback.name}()`, () => {
     });
 
     describe("type-based fallback matching", () => {
-        it("renders a zip field when type is 'ZIP' even with non-standard slotName", () => {
+        it("normalizes name to 'zip' when type is 'ZIP' with non-standard slotName", () => {
             const form = getContactFormFallback(
                 {
                     capture: {
@@ -3851,13 +3851,13 @@ describe(`#${getContactFormFallback.name}()`, () => {
             );
 
             const contactStep = form.steps.find((s) => s.name === "contact_info")!;
-            const zipField = contactStep.fields.find((f) => f.name === "zip_code") as FormTextInput;
+            const zipField = contactStep.fields.find((f) => f.name === "zip") as FormTextInput;
             expect(zipField).to.exist;
             expect(zipField.format).to.equal("ZIP_CODE");
             expect(zipField.maxLength).to.equal(10);
         });
 
-        it("renders a phone field when type is 'PHONE' even with non-standard slotName", () => {
+        it("normalizes name to 'phone' and includes in contact-only form with non-standard slotName", () => {
             const form = getContactFormFallback(
                 {
                     capture: {
@@ -3879,14 +3879,77 @@ describe(`#${getContactFormFallback.name}()`, () => {
                         ],
                     },
                 },
-                { enablePreferredTime: true },
+                {},
             );
 
-            const contactStep = form.steps.find((s) => s.name === "contact_info")!;
-            const phoneField = contactStep.fields.find((f) => f.name === "phone_number") as FormTextInput;
+            const contactStep = form.steps[0];
+            const phoneField = contactStep.fields.find((f) => f.name === "phone") as FormTextInput;
             expect(phoneField).to.exist;
             expect(phoneField.format).to.equal("PHONE");
             expect(phoneField.maxLength).to.equal(15);
+        });
+
+        it("normalizes name to 'email' with non-standard slotName", () => {
+            const form = getContactFormFallback(
+                {
+                    capture: {
+                        data: [
+                            {
+                                slotName: "full_name",
+                                active: true,
+                                type: "FULL_NAME" as const,
+                                questionContentKey: "NameQuestionContent",
+                                required: true,
+                            },
+                            {
+                                slotName: "email_address",
+                                active: true,
+                                type: "EMAIL" as const,
+                                questionContentKey: "EmailQuestionContent",
+                                required: false,
+                            },
+                        ],
+                    },
+                },
+                {},
+            );
+
+            const contactStep = form.steps[0];
+            const emailField = contactStep.fields.find((f) => f.name === "email") as FormTextInput;
+            expect(emailField).to.exist;
+            expect(emailField.format).to.equal("EMAIL");
+            expect(emailField.maxLength).to.equal(254);
+        });
+
+        it("respects MESSAGE type fallback for required flag", () => {
+            const form = getContactFormFallback(
+                {
+                    capture: {
+                        data: [
+                            {
+                                slotName: "full_name",
+                                active: true,
+                                type: "FULL_NAME" as const,
+                                questionContentKey: "NameQuestionContent",
+                                required: true,
+                            },
+                            {
+                                slotName: "notes",
+                                active: true,
+                                type: "MESSAGE" as const,
+                                questionContentKey: "MessageQuestionContent",
+                                required: false,
+                            },
+                        ],
+                    },
+                },
+                {},
+            );
+
+            const contactStep = form.steps[0];
+            const messageField = contactStep.fields.find((f) => f.name === "message") as FormTextInput;
+            expect(messageField).to.exist;
+            expect(messageField.mandatory).to.be.false;
         });
     });
 });

--- a/src/strategies/utils/__test__/forms.test.ts
+++ b/src/strategies/utils/__test__/forms.test.ts
@@ -3858,6 +3858,94 @@ describe(`#${getContactFormFallback.name}()`, () => {
             expect(orgField).to.exist;
             expect(orgField.mandatory).to.be.true;
         });
+
+        it("defaults company to optional when required is undefined", () => {
+            const form = getContactFormFallback(
+                {
+                    capture: {
+                        data: [
+                            {
+                                slotName: "full_name",
+                                active: true,
+                                type: "FULL_NAME" as const,
+                                questionContentKey: "NameQuestionContent",
+                                required: true,
+                            },
+                            {
+                                slotName: "company",
+                                active: true,
+                                type: "COMPANY" as const,
+                                questionContentKey: "CompanyQuestionContent",
+                            },
+                        ],
+                    },
+                },
+                {},
+            );
+
+            const contactStep = form.steps[0];
+            const companyField = contactStep.fields.find((f) => f.name === "company") as FormTextInput;
+            expect(companyField).to.exist;
+            expect(companyField.mandatory).to.equal(false);
+        });
+
+        it("renders both company and organization in contact-only form", () => {
+            const form = getContactFormFallback(
+                {
+                    capture: {
+                        data: [
+                            {
+                                slotName: "full_name",
+                                active: true,
+                                type: "FULL_NAME" as const,
+                                questionContentKey: "NameQuestionContent",
+                                required: true,
+                            },
+                            {
+                                slotName: "phone",
+                                active: true,
+                                type: "PHONE" as const,
+                                questionContentKey: "PhoneQuestionContent",
+                                required: true,
+                            },
+                            {
+                                slotName: "company",
+                                active: true,
+                                type: "COMPANY" as const,
+                                questionContentKey: "CompanyQuestionContent",
+                                required: false,
+                            },
+                            {
+                                slotName: "organization",
+                                active: true,
+                                type: "ORGANIZATION" as const,
+                                questionContentKey: "OrgQuestionContent",
+                                required: false,
+                            },
+                        ],
+                    },
+                },
+                {},
+            );
+
+            expect(form.name).to.equal("contact_us_only");
+            const contactStep = form.steps[0];
+            const fieldNames = contactStep.fields.map((f) => f.name);
+
+            // Both should be present
+            expect(fieldNames).to.include("company");
+            expect(fieldNames).to.include("organization");
+
+            // Company and org should appear after phone but before message
+            const phoneIdx = fieldNames.indexOf("phone");
+            const companyIdx = fieldNames.indexOf("company");
+            const orgIdx = fieldNames.indexOf("organization");
+            const messageIdx = fieldNames.indexOf("message");
+
+            expect(companyIdx).to.be.greaterThan(phoneIdx);
+            expect(orgIdx).to.be.greaterThan(companyIdx);
+            expect(messageIdx).to.be.greaterThan(orgIdx);
+        });
     });
 
     describe("type-based fallback matching", () => {

--- a/src/strategies/utils/forms.ts
+++ b/src/strategies/utils/forms.ts
@@ -412,6 +412,7 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
                 const emailField: FormTextInput = {
                     ...field,
                     name: "email",
+                    label: "Email",
                     format: "EMAIL",
                     placeholder: "Your email address",
                     maxLength: 254,
@@ -421,6 +422,7 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
                 const phoneField: FormTextInput = {
                     ...field,
                     name: "phone",
+                    label: "Phone",
                     format: "PHONE",
                     placeholder: "Your phone number we can best reach you on",
                     maxLength: 15,
@@ -430,6 +432,7 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
                 const zipField: FormTextInput = {
                     ...field,
                     name: "zip",
+                    label: "Zip Code",
                     format: "ZIP_CODE",
                     placeholder: "Your zip code",
                     maxLength: 10,
@@ -439,6 +442,7 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
                 const addressField: FormFieldTextAddressInput = {
                     ...field,
                     name: "address",
+                    label: "Address",
                     format: "ADDRESS",
                     mapsBaseUrl: "https://places.xapp.ai",
                     maxLength: 500,

--- a/src/strategies/utils/forms.ts
+++ b/src/strategies/utils/forms.ts
@@ -408,6 +408,9 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
                     maxLength: 50,
                 };
                 CONTACT_FIELDS.push(lastNameField);
+            // Contact fields below default to optional (required === true) unlike name fields
+            // above which default to required (required !== false), since at least one name
+            // field is always enforced separately.
             } else if (dataField.slotName === "email" || dataField.type === "EMAIL") {
                 const emailField: FormTextInput = {
                     ...field,
@@ -466,7 +469,6 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
                 const companyField: FormTextInput = {
                     ...field,
                     name: "company",
-                    multiline: false,
                     label: "Company",
                     placeholder: "Your company name",
                     mandatory: dataField.required === true,
@@ -477,7 +479,6 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
                 const organizationField: FormTextInput = {
                     ...field,
                     name: "organization",
-                    multiline: false,
                     label: "Organization",
                     placeholder: "Your organization name",
                     mandatory: dataField.required === true,

--- a/src/strategies/utils/forms.ts
+++ b/src/strategies/utils/forms.ts
@@ -375,7 +375,7 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
 
             // Handle name fields (full_name, first_name, last_name)
 
-            if (dataField.slotName === "full_name" || dataField.slotName === "name") {
+            if (dataField.slotName === "full_name" || dataField.slotName === "name" || dataField.type === "FULL_NAME") {
                 const namefield: FormTextInput = {
                     ...field,
                     name: "full_name",
@@ -386,7 +386,7 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
                     maxLength: 100,
                 };
                 CONTACT_FIELDS.push(namefield);
-            } else if (dataField.slotName === "first_name") {
+            } else if (dataField.slotName === "first_name" || dataField.type === "FIRST_NAME") {
                 const firstNameField: FormTextInput = {
                     ...field,
                     name: "first_name",
@@ -397,7 +397,7 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
                     maxLength: 50,
                 };
                 CONTACT_FIELDS.push(firstNameField);
-            } else if (dataField.slotName === "last_name") {
+            } else if (dataField.slotName === "last_name" || dataField.type === "LAST_NAME") {
                 const lastNameField: FormTextInput = {
                     ...field,
                     name: "last_name",
@@ -408,7 +408,7 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
                     maxLength: 50,
                 };
                 CONTACT_FIELDS.push(lastNameField);
-            } else if (dataField.slotName === "email") {
+            } else if (dataField.slotName === "email" || dataField.type === "EMAIL") {
                 const emailField: FormTextInput = {
                     ...field,
                     format: "EMAIL",
@@ -416,7 +416,7 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
                     maxLength: 254,
                 };
                 CONTACT_FIELDS.push(emailField);
-            } else if (dataField.slotName === "phone") {
+            } else if (dataField.slotName === "phone" || dataField.type === "PHONE") {
                 const phoneField: FormTextInput = {
                     ...field,
                     format: "PHONE",
@@ -424,7 +424,7 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
                     maxLength: 15,
                 };
                 CONTACT_FIELDS.push(phoneField);
-            } else if (dataField.slotName === "zip") {
+            } else if (dataField.slotName === "zip" || dataField.type === "ZIP") {
                 const zipField: FormTextInput = {
                     ...field,
                     format: "ZIP_CODE",
@@ -432,7 +432,7 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
                     maxLength: 10,
                 };
                 CONTACT_FIELDS.push(zipField);
-            } else if (dataField.slotName === "address") {
+            } else if (dataField.slotName === "address" || dataField.type === "ADDRESS") {
                 const addressField: FormFieldTextAddressInput = {
                     ...field,
                     format: "ADDRESS",
@@ -446,11 +446,31 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
                     addressField.mapsUrlQueryParams = data.capture.addressAutocompleteParams;
                 }
                 CONTACT_FIELDS.push(addressField);
-            } else if (dataField.slotName === "message") {
+            } else if (dataField.slotName === "message" || dataField.type === "MESSAGE") {
                 if (typeof dataField.required === "boolean") {
                     requiredMessage = dataField.required;
                 }
-            } else if (dataField.slotName === "selection") {
+            } else if (dataField.slotName === "company" || dataField.type === "COMPANY") {
+                const companyField: FormTextInput = {
+                    ...field,
+                    name: "company",
+                    multiline: false,
+                    label: "Company",
+                    placeholder: "Your company name",
+                    maxLength: 100,
+                };
+                CONTACT_FIELDS.push(companyField);
+            } else if (dataField.slotName === "organization" || dataField.type === "ORGANIZATION") {
+                const organizationField: FormTextInput = {
+                    ...field,
+                    name: "organization",
+                    multiline: false,
+                    label: "Organization",
+                    placeholder: "Your organization name",
+                    maxLength: 100,
+                };
+                CONTACT_FIELDS.push(organizationField);
+            } else if (dataField.slotName === "selection" || dataField.type === "SELECTION") {
                 const selectionField: FormChipsInput = {
                     type: "CHIPS",
                     name: "selection",
@@ -1032,6 +1052,13 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
     if (emailFieldIndex >= 0) {
         contactOnlyFields.push({ ...CONTACT_FIELDS[emailFieldIndex] });
     }
+
+    // Add company/organization fields if they exist
+    CONTACT_FIELDS.forEach((field) => {
+        if (field.name === "company" || field.name === "organization") {
+            contactOnlyFields.push({ ...field });
+        }
+    });
 
     // message
     contactOnlyFields.push({

--- a/src/strategies/utils/forms.ts
+++ b/src/strategies/utils/forms.ts
@@ -465,6 +465,7 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
                     multiline: false,
                     label: "Company",
                     placeholder: "Your company name",
+                    mandatory: dataField.required === true, // default to false (optional) unless explicitly true
                     maxLength: 100,
                 };
                 CONTACT_FIELDS.push(companyField);
@@ -475,6 +476,7 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
                     multiline: false,
                     label: "Organization",
                     placeholder: "Your organization name",
+                    mandatory: dataField.required === true, // default to false (optional) unless explicitly true
                     maxLength: 100,
                 };
                 CONTACT_FIELDS.push(organizationField);

--- a/src/strategies/utils/forms.ts
+++ b/src/strategies/utils/forms.ts
@@ -415,6 +415,7 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
                     label: "Email",
                     format: "EMAIL",
                     placeholder: "Your email address",
+                    mandatory: dataField.required === true,
                     maxLength: 254,
                 };
                 CONTACT_FIELDS.push(emailField);
@@ -425,6 +426,7 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
                     label: "Phone",
                     format: "PHONE",
                     placeholder: "Your phone number we can best reach you on",
+                    mandatory: dataField.required === true,
                     maxLength: 15,
                 };
                 CONTACT_FIELDS.push(phoneField);
@@ -435,6 +437,7 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
                     label: "Zip Code",
                     format: "ZIP_CODE",
                     placeholder: "Your zip code",
+                    mandatory: dataField.required === true,
                     maxLength: 10,
                 };
                 CONTACT_FIELDS.push(zipField);
@@ -444,6 +447,7 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
                     name: "address",
                     label: "Address",
                     format: "ADDRESS",
+                    mandatory: dataField.required === true,
                     mapsBaseUrl: "https://places.xapp.ai",
                     maxLength: 500,
                 };
@@ -465,7 +469,7 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
                     multiline: false,
                     label: "Company",
                     placeholder: "Your company name",
-                    mandatory: dataField.required === true, // default to false (optional) unless explicitly true
+                    mandatory: dataField.required === true,
                     maxLength: 100,
                 };
                 CONTACT_FIELDS.push(companyField);
@@ -476,7 +480,7 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
                     multiline: false,
                     label: "Organization",
                     placeholder: "Your organization name",
-                    mandatory: dataField.required === true, // default to false (optional) unless explicitly true
+                    mandatory: dataField.required === true,
                     maxLength: 100,
                 };
                 CONTACT_FIELDS.push(organizationField);

--- a/src/strategies/utils/forms.ts
+++ b/src/strategies/utils/forms.ts
@@ -411,6 +411,7 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
             } else if (dataField.slotName === "email" || dataField.type === "EMAIL") {
                 const emailField: FormTextInput = {
                     ...field,
+                    name: "email",
                     format: "EMAIL",
                     placeholder: "Your email address",
                     maxLength: 254,
@@ -419,6 +420,7 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
             } else if (dataField.slotName === "phone" || dataField.type === "PHONE") {
                 const phoneField: FormTextInput = {
                     ...field,
+                    name: "phone",
                     format: "PHONE",
                     placeholder: "Your phone number we can best reach you on",
                     maxLength: 15,
@@ -427,6 +429,7 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
             } else if (dataField.slotName === "zip" || dataField.type === "ZIP") {
                 const zipField: FormTextInput = {
                     ...field,
+                    name: "zip",
                     format: "ZIP_CODE",
                     placeholder: "Your zip code",
                     maxLength: 10,
@@ -435,6 +438,7 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
             } else if (dataField.slotName === "address" || dataField.type === "ADDRESS") {
                 const addressField: FormFieldTextAddressInput = {
                     ...field,
+                    name: "address",
                     format: "ADDRESS",
                     mapsBaseUrl: "https://places.xapp.ai",
                     maxLength: 500,
@@ -1054,11 +1058,14 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
     }
 
     // Add company/organization fields if they exist
-    CONTACT_FIELDS.forEach((field) => {
-        if (field.name === "company" || field.name === "organization") {
-            contactOnlyFields.push({ ...field });
-        }
-    });
+    const companyFieldIndex = CONTACT_FIELDS.findIndex((f) => f.name === "company");
+    const orgFieldIndex = CONTACT_FIELDS.findIndex((f) => f.name === "organization");
+    if (companyFieldIndex >= 0) {
+        contactOnlyFields.push({ ...CONTACT_FIELDS[companyFieldIndex] });
+    }
+    if (orgFieldIndex >= 0) {
+        contactOnlyFields.push({ ...CONTACT_FIELDS[orgFieldIndex] });
+    }
 
     // message
     contactOnlyFields.push({
@@ -1067,7 +1074,7 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
         rows: 3,
         type: "TEXT",
         multiline: true,
-        mandatory: true,
+        mandatory: requiredMessage,
         maxLength: messageMaxLength,
     });
 


### PR DESCRIPTION
## Summary
- Add `dataField.type` fallback matching to all existing form field branches (FULL_NAME, FIRST_NAME, LAST_NAME, EMAIL, PHONE, ZIP, ADDRESS, MESSAGE, SELECTION) so fields with non-standard `slotName` values are still recognized
- Add new COMPANY and ORGANIZATION field handlers that generate text inputs with appropriate labels and placeholders
- Include company/organization fields in the contact-only form variant
- Normalize all field `name` and `label` values to canonical strings regardless of `slotName`
- Normalize `mandatory` to `dataField.required === true` across all type-fallback branches for consistency

### Behavior change: contact-only message field `mandatory`
The contact-only form previously hardcoded `mandatory: true` for the message field, ignoring the `requiredMessage` variable that was already respected in the multi-step form. This is now changed to use `mandatory: requiredMessage` (which defaults to `true`), so a MESSAGE data field with `required: false` is correctly honored in both form variants.

## Test plan
- [x] COMPANY field via `slotName` and via `type` fallback
- [x] ORGANIZATION field via `type` fallback, with `required: true` and `required: false`
- [x] `required: undefined` defaults to optional for COMPANY
- [x] Both COMPANY and ORGANIZATION present simultaneously with ordering assertions
- [x] Type-based fallback: ZIP, PHONE, EMAIL with non-standard slotNames
- [x] MESSAGE type fallback for `required` flag
- [x] Label correctness on type-fallback matches
- [x] All 205 existing + new tests pass
- [x] Build and lint clean

🤖 Generated with [Claude Code](https://claude.ai/code)