### PR TITLE
fix: update mapsBaseUrl to api.xapp.ai

### DIFF
--- a/src/strategies/utils/__test__/forms.test.ts
+++ b/src/strategies/utils/__test__/forms.test.ts
@@ -321,6 +321,7 @@ describe(`#${getFormResponse.name}()`, () => {
                         .fields[3] as FormFieldTextAddressInput;
                     expect(addressField.name).to.equal("address");
                     expect(addressField.mandatory).to.be.true;
+                    expect(addressField.mapsBaseUrl).to.equal("https://api.xapp.ai");
                     expect(addressField.mapsUrlQueryParams).to.deep.equal({ components: "country:us" });
 
                     // check the preferredTime step and check the conditional

--- a/src/strategies/utils/forms.ts
+++ b/src/strategies/utils/forms.ts
@@ -454,7 +454,7 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
                     label: "Address",
                     format: "ADDRESS",
                     mandatory: dataField.required === true,
-                    mapsBaseUrl: "https://places.xapp.ai",
+                    mapsBaseUrl: "https://api.xapp.ai",
                     maxLength: 500,
                 };
                 // Check for mapsUrlQueryParams on the dataField first, then fall back to capture-level config


### PR DESCRIPTION
## Summary
- Updates the hardcoded `mapsBaseUrl` default from `https://places.xapp.ai` to `https://api.xapp.ai` in the address field builder
- Fixes CORS errors on `book.xapp.ai` where the form widget's New Places API v1 POST requests to `places.xapp.ai/places/autocomplete` were being blocked
- Related to chat-widget PR: https://github.com/XappMedia/chat-widget/pull/1449

## Test plan
- [ ] Deploy and verify address autocomplete works on book.xapp.ai without CORS errors
- [ ] Verify autocomplete suggestions still return correctly

---
🤖 Created with [Claude Code](https://claude.ai/code)