### PR TITLE
feat!: hide First Available Date chip by default, add showFirstAvailableDay alias

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -42,7 +42,7 @@ export interface ContactCaptureService {
     requiresDate?: boolean;
 }
 
-export interface ContactCaptureData extends QuestionAnsweringData, Pick<FormResponseProps, "enablePreferredTime" | "turnOffFirstAvailableDay" | "preferredTimeOptions" | "preferredDateConfirmationText" | "firstPageInputType" | "showFirstPageMessage" | "serviceSelectionTitle" | "preferredTimeNotification"> {
+export interface ContactCaptureData extends QuestionAnsweringData, Pick<FormResponseProps, "enablePreferredTime" | "turnOffFirstAvailableDay" | "showFirstAvailableDay" | "preferredTimeOptions" | "preferredDateConfirmationText" | "firstPageInputType" | "showFirstPageMessage" | "serviceSelectionTitle" | "preferredTimeNotification"> {
     /**
      * It will not capture the lead and instead provide contact information.
      *

--- a/src/strategies/utils/__test__/forms.test.ts
+++ b/src/strategies/utils/__test__/forms.test.ts
@@ -8,6 +8,7 @@ import {
     FormDropdownInput,
     FormFieldTextAddressInput,
     FormTextInput,
+    MultistepForm,
     SelectableItem,
 } from "stentor-models";
 
@@ -1703,6 +1704,8 @@ describe(`#${getContactFormFallback.name}()`, () => {
         });
     });
     describe("when turnOffFirstAvailableDay is not set (new default)", () => {
+        const findStep = (form: MultistepForm, name: string) => form.steps.find((s) => s.name === name);
+
         it("omits preferred_date chip by default (data has no flag)", () => {
             const form = getContactFormFallback(
                 { capture: SIMPLE_BLUEPRINT },
@@ -1711,10 +1714,10 @@ describe(`#${getContactFormFallback.name}()`, () => {
 
             expect(form).to.exist;
 
-            const preferredTimeStep = form.steps[2]; // preferred_time step
+            const preferredTimeStep = findStep(form, "preferred_time");
             expect(preferredTimeStep).to.exist;
 
-            const preferredDateField = preferredTimeStep.fields.find((field) => field.name === "preferred_date");
+            const preferredDateField = preferredTimeStep!.fields.find((field) => field.name === "preferred_date");
             expect(preferredDateField, "preferred_date chip should be hidden by default").to.be.undefined;
         });
 
@@ -1724,8 +1727,8 @@ describe(`#${getContactFormFallback.name}()`, () => {
                 { enablePreferredTime: true },
             );
 
-            const preferredTimeStep = form.steps[2];
-            const dateTimeField = preferredTimeStep.fields.find((field) => field.name === "dateTime");
+            const preferredTimeStep = findStep(form, "preferred_time");
+            const dateTimeField = preferredTimeStep!.fields.find((field) => field.name === "dateTime");
             expect(dateTimeField).to.exist;
             expect(dateTimeField?.mandatory).to.be.true;
             expect(dateTimeField?.mandatoryGroup).to.be.undefined;
@@ -1741,8 +1744,8 @@ describe(`#${getContactFormFallback.name}()`, () => {
                 { enablePreferredTime: true },
             );
 
-            const preferredTimeStep = form.steps[2];
-            const preferredDateField = preferredTimeStep.fields.find((field) => field.name === "preferred_date");
+            const preferredTimeStep = findStep(form, "preferred_time");
+            const preferredDateField = preferredTimeStep!.fields.find((field) => field.name === "preferred_date");
             expect(preferredDateField).to.be.undefined;
         });
 
@@ -1752,8 +1755,8 @@ describe(`#${getContactFormFallback.name}()`, () => {
                 { enablePreferredTime: true, turnOffFirstAvailableDay: undefined },
             );
 
-            const preferredTimeStep = form.steps[2];
-            const preferredDateField = preferredTimeStep.fields.find((field) => field.name === "preferred_date");
+            const preferredTimeStep = findStep(form, "preferred_time");
+            const preferredDateField = preferredTimeStep!.fields.find((field) => field.name === "preferred_date");
             expect(preferredDateField).to.be.undefined;
         });
 
@@ -1766,8 +1769,8 @@ describe(`#${getContactFormFallback.name}()`, () => {
                 { enablePreferredTime: true },
             );
 
-            const preferredTimeStep = form.steps[2];
-            const preferredDateField = preferredTimeStep.fields.find((field) => field.name === "preferred_date");
+            const preferredTimeStep = findStep(form, "preferred_time");
+            const preferredDateField = preferredTimeStep!.fields.find((field) => field.name === "preferred_date");
             expect(preferredDateField).to.exist;
             expect(preferredDateField?.type).to.equal("CHIPS");
         });
@@ -1781,9 +1784,123 @@ describe(`#${getContactFormFallback.name}()`, () => {
                 { enablePreferredTime: true, turnOffFirstAvailableDay: false },
             );
 
-            const preferredTimeStep = form.steps[2];
-            const preferredDateField = preferredTimeStep.fields.find((field) => field.name === "preferred_date");
+            const preferredTimeStep = findStep(form, "preferred_time");
+            const preferredDateField = preferredTimeStep!.fields.find((field) => field.name === "preferred_date");
             expect(preferredDateField, "props.false should override data.true and show chip").to.exist;
+        });
+
+        // Edge case from PR #656 review: an explicit `undefined` on props clobbers
+        // a `false` in data because `...props` spread copies own properties even
+        // when their value is undefined. The merge in getContactFormFallback now
+        // guards against this for turnOffFirstAvailableDay, so data wins.
+        it("ignores explicit props.turnOffFirstAvailableDay=undefined when data.turnOffFirstAvailableDay=false (shows chip)", () => {
+            const form = getContactFormFallback(
+                {
+                    capture: SIMPLE_BLUEPRINT,
+                    turnOffFirstAvailableDay: false,
+                },
+                { enablePreferredTime: true, turnOffFirstAvailableDay: undefined },
+            );
+
+            const preferredTimeStep = findStep(form, "preferred_time");
+            const preferredDateField = preferredTimeStep!.fields.find((field) => field.name === "preferred_date");
+            expect(
+                preferredDateField,
+                "explicit undefined on props must not clobber a boolean from data",
+            ).to.exist;
+        });
+    });
+    describe("when passed showFirstAvailableDay (positively-named alias)", () => {
+        const findStep = (form: MultistepForm, name: string) => form.steps.find((s) => s.name === name);
+
+        it("shows preferred_date chip when showFirstAvailableDay is true", () => {
+            const form = getContactFormFallback(
+                {
+                    capture: SIMPLE_BLUEPRINT,
+                    showFirstAvailableDay: true,
+                },
+                { enablePreferredTime: true },
+            );
+
+            const preferredTimeStep = findStep(form, "preferred_time");
+            const preferredDateField = preferredTimeStep!.fields.find((field) => field.name === "preferred_date");
+            expect(preferredDateField).to.exist;
+            expect(preferredDateField?.type).to.equal("CHIPS");
+
+            const dateTimeField = preferredTimeStep!.fields.find((field) => field.name === "dateTime");
+            expect(dateTimeField?.mandatoryGroup).to.equal("date");
+        });
+
+        it("hides preferred_date chip when showFirstAvailableDay is false", () => {
+            const form = getContactFormFallback(
+                {
+                    capture: SIMPLE_BLUEPRINT,
+                    showFirstAvailableDay: false,
+                },
+                { enablePreferredTime: true },
+            );
+
+            const preferredTimeStep = findStep(form, "preferred_time");
+            const preferredDateField = preferredTimeStep!.fields.find((field) => field.name === "preferred_date");
+            expect(preferredDateField).to.be.undefined;
+
+            const dateTimeField = preferredTimeStep!.fields.find((field) => field.name === "dateTime");
+            expect(dateTimeField?.mandatory).to.be.true;
+            expect(dateTimeField?.mandatoryGroup).to.be.undefined;
+        });
+
+        it("takes precedence over turnOffFirstAvailableDay when both are set", () => {
+            // showFirstAvailableDay=true overrides turnOffFirstAvailableDay=true → chip shown
+            const formA = getContactFormFallback(
+                {
+                    capture: SIMPLE_BLUEPRINT,
+                    showFirstAvailableDay: true,
+                    turnOffFirstAvailableDay: true,
+                },
+                { enablePreferredTime: true },
+            );
+            const stepA = findStep(formA, "preferred_time");
+            expect(stepA!.fields.find((f) => f.name === "preferred_date")).to.exist;
+
+            // showFirstAvailableDay=false overrides turnOffFirstAvailableDay=false → chip hidden
+            const formB = getContactFormFallback(
+                {
+                    capture: SIMPLE_BLUEPRINT,
+                    showFirstAvailableDay: false,
+                    turnOffFirstAvailableDay: false,
+                },
+                { enablePreferredTime: true },
+            );
+            const stepB = findStep(formB, "preferred_time");
+            expect(stepB!.fields.find((f) => f.name === "preferred_date")).to.be.undefined;
+        });
+
+        it("falls back to turnOffFirstAvailableDay when showFirstAvailableDay is unset", () => {
+            const form = getContactFormFallback(
+                {
+                    capture: SIMPLE_BLUEPRINT,
+                    turnOffFirstAvailableDay: false,
+                },
+                { enablePreferredTime: true },
+            );
+
+            const preferredTimeStep = findStep(form, "preferred_time");
+            const preferredDateField = preferredTimeStep!.fields.find((field) => field.name === "preferred_date");
+            expect(preferredDateField).to.exist;
+        });
+
+        it("props.showFirstAvailableDay overrides data.showFirstAvailableDay", () => {
+            const form = getContactFormFallback(
+                {
+                    capture: SIMPLE_BLUEPRINT,
+                    showFirstAvailableDay: true,
+                },
+                { enablePreferredTime: true, showFirstAvailableDay: false },
+            );
+
+            const preferredTimeStep = findStep(form, "preferred_time");
+            const preferredDateField = preferredTimeStep!.fields.find((field) => field.name === "preferred_date");
+            expect(preferredDateField).to.be.undefined;
         });
     });
     describe("when passed preferredTimeOptions", () => {

--- a/src/strategies/utils/__test__/forms.test.ts
+++ b/src/strategies/utils/__test__/forms.test.ts
@@ -1675,7 +1675,7 @@ describe(`#${getContactFormFallback.name}()`, () => {
             expect(dateTimeField?.mandatoryError).to.equal("Please select a date");
         });
 
-        it("keeps default behavior when turnOffFirstAvailableDay is false", () => {
+        it("shows preferred_date chip when turnOffFirstAvailableDay is explicitly false (opt-in)", () => {
             const form = getContactFormFallback(
                 {
                     capture: SIMPLE_BLUEPRINT,
@@ -1700,6 +1700,90 @@ describe(`#${getContactFormFallback.name}()`, () => {
             expect(dateTimeField?.mandatory).to.be.undefined;
             expect(dateTimeField?.mandatoryGroup).to.equal("date");
             expect(dateTimeField?.mandatoryError).to.equal("Please select either a date or first available date");
+        });
+    });
+    describe("when turnOffFirstAvailableDay is not set (new default)", () => {
+        it("omits preferred_date chip by default (data has no flag)", () => {
+            const form = getContactFormFallback(
+                { capture: SIMPLE_BLUEPRINT },
+                { enablePreferredTime: true },
+            );
+
+            expect(form).to.exist;
+
+            const preferredTimeStep = form.steps[2]; // preferred_time step
+            expect(preferredTimeStep).to.exist;
+
+            const preferredDateField = preferredTimeStep.fields.find((field) => field.name === "preferred_date");
+            expect(preferredDateField, "preferred_date chip should be hidden by default").to.be.undefined;
+        });
+
+        it("makes dateTime mandatory without a mandatoryGroup by default", () => {
+            const form = getContactFormFallback(
+                { capture: SIMPLE_BLUEPRINT },
+                { enablePreferredTime: true },
+            );
+
+            const preferredTimeStep = form.steps[2];
+            const dateTimeField = preferredTimeStep.fields.find((field) => field.name === "dateTime");
+            expect(dateTimeField).to.exist;
+            expect(dateTimeField?.mandatory).to.be.true;
+            expect(dateTimeField?.mandatoryGroup).to.be.undefined;
+            expect(dateTimeField?.mandatoryError).to.equal("Please select a date");
+        });
+
+        it("omits preferred_date chip when data field is explicitly undefined", () => {
+            const form = getContactFormFallback(
+                {
+                    capture: SIMPLE_BLUEPRINT,
+                    turnOffFirstAvailableDay: undefined,
+                },
+                { enablePreferredTime: true },
+            );
+
+            const preferredTimeStep = form.steps[2];
+            const preferredDateField = preferredTimeStep.fields.find((field) => field.name === "preferred_date");
+            expect(preferredDateField).to.be.undefined;
+        });
+
+        it("omits preferred_date chip when props has no flag and data has no flag", () => {
+            const form = getContactFormFallback(
+                { capture: SIMPLE_BLUEPRINT },
+                { enablePreferredTime: true, turnOffFirstAvailableDay: undefined },
+            );
+
+            const preferredTimeStep = form.steps[2];
+            const preferredDateField = preferredTimeStep.fields.find((field) => field.name === "preferred_date");
+            expect(preferredDateField).to.be.undefined;
+        });
+
+        it("respects explicit data.turnOffFirstAvailableDay=false even with no props flag (shows chip)", () => {
+            const form = getContactFormFallback(
+                {
+                    capture: SIMPLE_BLUEPRINT,
+                    turnOffFirstAvailableDay: false,
+                },
+                { enablePreferredTime: true },
+            );
+
+            const preferredTimeStep = form.steps[2];
+            const preferredDateField = preferredTimeStep.fields.find((field) => field.name === "preferred_date");
+            expect(preferredDateField).to.exist;
+            expect(preferredDateField?.type).to.equal("CHIPS");
+        });
+
+        it("respects explicit props.turnOffFirstAvailableDay=false over data.turnOffFirstAvailableDay=true (shows chip)", () => {
+            const form = getContactFormFallback(
+                {
+                    capture: SIMPLE_BLUEPRINT,
+                    turnOffFirstAvailableDay: true,
+                },
+                { enablePreferredTime: true, turnOffFirstAvailableDay: false },
+            );
+
+            const preferredTimeStep = form.steps[2];
+            const preferredDateField = preferredTimeStep.fields.find((field) => field.name === "preferred_date");
+            expect(preferredDateField, "props.false should override data.true and show chip").to.exist;
         });
     });
     describe("when passed preferredTimeOptions", () => {

--- a/src/strategies/utils/forms.ts
+++ b/src/strategies/utils/forms.ts
@@ -173,8 +173,12 @@ export interface FormResponseProps {
      */
     fields?: DataDescriptorBase[];
     /**
-     * When true, removes the 'preferred_date' field from the preferred time form,
-     * removes the mandatoryGroup from the dateTime field, and makes dateTime mandatory.
+     * Controls the 'First Available Date' chip on the preferred time form.
+     *
+     * - undefined (default) or true: chip is hidden; dateTime is mandatory with no mandatoryGroup.
+     * - false: chip is shown; dateTime uses a mandatoryGroup so either a date or the chip is required.
+     *
+     * Existing handlers that do not set this field will get the hidden-by-default behavior.
      */
     turnOffFirstAvailableDay?: boolean;
     /**
@@ -835,9 +839,10 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
         });
     }
 
-    // Add dateTime field
-    if (props.turnOffFirstAvailableDay) {
-        // When turnOffFirstAvailableDay is true, make dateTime mandatory without mandatoryGroup
+    // Add dateTime field.
+    // Default (undefined) and true both HIDE the 'First Available Date' chip.
+    // Only an explicit `false` opts in to show it.
+    if (props.turnOffFirstAvailableDay !== false) {
         preferredTimeFields.push({
             name: "dateTime",
             title: "Preferred date",
@@ -848,7 +853,6 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
             defaultBusyDays: data.availabilitySettings?.defaultBusyDays,
         });
     } else {
-        // Default behavior with mandatoryGroup
         preferredTimeFields.push({
             name: "dateTime",
             title: "Preferred date",
@@ -859,7 +863,6 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
             defaultBusyDays: data.availabilitySettings?.defaultBusyDays,
         });
 
-        // Only add preferred_date field if turnOffFirstAvailableDay is not set
         preferredTimeFields.push({
             name: "preferred_date",
             type: "CHIPS",

--- a/src/strategies/utils/forms.ts
+++ b/src/strategies/utils/forms.ts
@@ -179,8 +179,21 @@ export interface FormResponseProps {
      * - false: chip is shown; dateTime uses a mandatoryGroup so either a date or the chip is required.
      *
      * Existing handlers that do not set this field will get the hidden-by-default behavior.
+     *
+     * @deprecated Prefer the positively-named {@link showFirstAvailableDay}. When both are set,
+     * `showFirstAvailableDay` wins.
      */
     turnOffFirstAvailableDay?: boolean;
+    /**
+     * Positively-named control for the 'First Available Date' chip on the preferred time form.
+     *
+     * - true: chip is shown; dateTime uses a mandatoryGroup so either a date or the chip is required.
+     * - false: chip is hidden; dateTime is mandatory with no mandatoryGroup.
+     * - undefined (default): fall back to {@link turnOffFirstAvailableDay}, which itself defaults to hidden.
+     *
+     * Preferred over `turnOffFirstAvailableDay` to avoid the double-negative read at call sites.
+     */
+    showFirstAvailableDay?: boolean;
     /**
      * Custom options for the preferred time field. Replaces the default items
      * (First Available Time, Morning, Afternoon) with user-defined options.
@@ -270,6 +283,9 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
         ...(typeof data.turnOffFirstAvailableDay === "boolean" && {
             turnOffFirstAvailableDay: data.turnOffFirstAvailableDay,
         }),
+        ...(typeof data.showFirstAvailableDay === "boolean" && {
+            showFirstAvailableDay: data.showFirstAvailableDay,
+        }),
         ...(existsAndNotEmpty(data.preferredTimeOptions) && { preferredTimeOptions: data.preferredTimeOptions }),
         ...(data.preferredDateConfirmationText && {
             preferredDateConfirmationText: data.preferredDateConfirmationText,
@@ -284,6 +300,17 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
         ...(data.capture?.disclaimer && { disclaimer: data.capture.disclaimer }),
         ...props, // Props override data
     };
+
+    // An explicit `undefined` on props would otherwise clobber a boolean from
+    // data (the spread copies own keys regardless of value). For the
+    // chip-visibility flags this matters more under the new hidden-by-default
+    // semantics, so restore data when props' value is not a boolean.
+    if (typeof props.turnOffFirstAvailableDay !== "boolean" && typeof data.turnOffFirstAvailableDay === "boolean") {
+        mergedProps.turnOffFirstAvailableDay = data.turnOffFirstAvailableDay;
+    }
+    if (typeof props.showFirstAvailableDay !== "boolean" && typeof data.showFirstAvailableDay === "boolean") {
+        mergedProps.showFirstAvailableDay = data.showFirstAvailableDay;
+    }
 
     // Use mergedProps instead of props throughout the rest of the function
     props = mergedProps;
@@ -839,10 +866,15 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
         });
     }
 
-    // Add dateTime field.
-    // Default (undefined) and true both HIDE the 'First Available Date' chip.
-    // Only an explicit `false` opts in to show it.
-    if (props.turnOffFirstAvailableDay !== false) {
+    // Resolve chip visibility. showFirstAvailableDay wins when set;
+    // otherwise fall back to turnOffFirstAvailableDay (legacy, double-negative).
+    // Default is hidden — only an explicit opt-in shows the chip.
+    const showFirstAvailableDayChip =
+        typeof props.showFirstAvailableDay === "boolean"
+            ? props.showFirstAvailableDay
+            : props.turnOffFirstAvailableDay === false;
+
+    if (!showFirstAvailableDayChip) {
         preferredTimeFields.push({
             name: "dateTime",
             title: "Preferred date",


### PR DESCRIPTION
## Summary

⚠️ **BREAKING CHANGE** — the default behavior of the "First Available Date" chip on the preferred time form is flipped.

- **Before:** Handlers that omitted `turnOffFirstAvailableDay` got the chip shown.
- **After:** Handlers that omit both flags get the chip **hidden**.
- **Migration:** Handlers that need the chip must opt in with either `showFirstAvailableDay: true` or `turnOffFirstAvailableDay: false`.

### Changes
- Flips the chip default in `getContactFormFallback`: `undefined`/`true` → hidden; only an explicit `false` (or new alias) opts in to show.
- Adds **`showFirstAvailableDay`** as a positively-named alias for `turnOffFirstAvailableDay` so call sites read naturally. When both are set, `showFirstAvailableDay` wins. `turnOffFirstAvailableDay` is marked `@deprecated` but still supported.
- Fixes a pre-existing merge bug: a props object with an explicit `undefined` for one of these flags would clobber a boolean from `data` (the spread copies own keys regardless of value). The merge now restores data's value when props' value isn't actually a boolean.
- JSDoc updated to describe the tri-state semantics for both flags.

## Test plan
- [x] `yarn test` — 229 passing (was 223), including:
  - 6 tests for the new hidden-by-default behavior
  - 1 test for the merge edge case (props `undefined` + data `false` → chip shown)
  - 5 tests for the `showFirstAvailableDay` alias
- [x] Existing `turnOffFirstAvailableDay: true` / `false` cases still pass
- [x] `yarn lint` — 0 errors
- [ ] Verify in the form-widget channel that an existing handler with no flag set no longer renders the chip

🤖 Generated with [Claude Code](https://claude.com/claude-code)