### PR TITLE
feat(availability): pass widget availability settings into getJobType; carry forced class on the lead

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "stentor-context": "1.72.4",
     "stentor-handler": "1.72.4",
     "stentor-logger": "1.72.4",
-    "stentor-models": "1.72.4",
+    "stentor-models": "1.73.0",
     "stentor-request": "1.72.4",
     "stentor-response": "1.72.4",
     "stentor-service-fetch": "1.72.4",

--- a/src/data.ts
+++ b/src/data.ts
@@ -95,7 +95,11 @@ export interface ContactCaptureData extends QuestionAnsweringData, Pick<FormResp
      */
     crmFlags?: object;
     /**
-     * Optional availability settings to be used when calling CRMService.getAvailability()
+     * Optional availability settings used when calling CRMService.getAvailability() and getJobType().
+     *
+     * By the time this handler runs, stentor-api has already deep-merged the app-level availability
+     * settings with this handler's own overrides, so this is the effective, resolved object — a
+     * campaign widget's forceAvailabilityClass / jobTypeClasses layered over the account defaults.
      */
     availabilitySettings?: CrmServiceAvailabilitySettings;
 }

--- a/src/strategies/FormResponseStrategy.ts
+++ b/src/strategies/FormResponseStrategy.ts
@@ -8,6 +8,7 @@ import {
     CrmServiceAvailability,
     CrmServiceAvailabilityOptions,
     CrmServiceAvailabilitySettings,
+    CrmServiceJobType,
     Response,
     Request,
     RequestSlotMap,
@@ -326,7 +327,14 @@ export class FormResponseStrategy implements ResponseStrategy {
 
                     // Pass the in-scope availability settings so forceAvailabilityClass /
                     // jobTypeClasses can influence which class the job resolves to (#663).
-                    const jobType = await crmService.getJobType(description, undefined, settings);
+                    // Guarded like getAvailability below: a classifier failure must not break the
+                    // whole request — we just skip the job-type-based availability refetch.
+                    let jobType: CrmServiceJobType | undefined;
+                    try {
+                        jobType = await crmService.getJobType(description, undefined, settings);
+                    } catch (e) {
+                        log().warn(`getJobType failed, skipping availability augmentation: ${(e as Error).message}`);
+                    }
                     const existingJobType = session.get(Constants.CONTACT_CAPTURE_JOB_TYPE);
 
                     // Only call if the jobType changed (visitor changed the description)

--- a/src/strategies/FormResponseStrategy.ts
+++ b/src/strategies/FormResponseStrategy.ts
@@ -230,7 +230,13 @@ export class FormResponseStrategy implements ResponseStrategy {
             externalId: hasSessionId(request) ? request.sessionId : "unknown",
             existingRefId,
             jobTypeId: jobType?.id,
-            avalabilityClassId: jobType?.class,
+            // Fall back to the widget's forced/default class when there is no AI-derived job type,
+            // so a force-classed campaign widget still tags its leads (#663). Note the existing
+            // misspelling of the key — handler.ts reads `extras.avalabilityClassId` verbatim.
+            avalabilityClassId:
+                jobType?.class ??
+                handler.data?.availabilitySettings?.forceAvailabilityClass ??
+                handler.data?.availabilitySettings?.defaultAvailabilityClass,
             crmFlags: handler.data?.crmFlags,
             isAbandoned,
         };
@@ -291,15 +297,19 @@ export class FormResponseStrategy implements ResponseStrategy {
         if (!busyDays && typeof crmService?.getAvailability === "function") {
             const options: CrmServiceAvailabilityOptions = { ...settings };
 
-            busyDays = await crmService.getAvailability(
-                {
-                    start: null,
-                    end: null,
-                },
-                options,
-            );
+            try {
+                busyDays = await crmService.getAvailability(
+                    {
+                        start: null,
+                        end: null,
+                    },
+                    options,
+                );
 
-            session.set(Constants.CONTACT_CAPTURE_BUSY_DAYS, busyDays);
+                session.set(Constants.CONTACT_CAPTURE_BUSY_DAYS, busyDays);
+            } catch (e) {
+                log().warn(`getAvailability failed, continuing without busy days: ${(e as Error).message}`);
+            }
         } else if (leadDataList?.data && typeof crmService?.getJobType === "function") {
             // Try to augment if we have a description
             const messageData = leadDataList.data.find((data) => {
@@ -314,7 +324,9 @@ export class FormResponseStrategy implements ResponseStrategy {
                 if (description !== existingDescription) {
                     session.set(Constants.CONTACT_CAPTURE_DESCRIPTION, description);
 
-                    const jobType = await crmService.getJobType(description);
+                    // Pass the in-scope availability settings so forceAvailabilityClass /
+                    // jobTypeClasses can influence which class the job resolves to (#663).
+                    const jobType = await crmService.getJobType(description, undefined, settings);
                     const existingJobType = session.get(Constants.CONTACT_CAPTURE_JOB_TYPE);
 
                     // Only call if the jobType changed (visitor changed the description)
@@ -332,15 +344,21 @@ export class FormResponseStrategy implements ResponseStrategy {
                             };
                         }
 
-                        busyDays = await crmService.getAvailability(
-                            {
-                                start: null,
-                                end: null,
-                            },
-                            options,
-                        );
+                        try {
+                            busyDays = await crmService.getAvailability(
+                                {
+                                    start: null,
+                                    end: null,
+                                },
+                                options,
+                            );
 
-                        session.set(Constants.CONTACT_CAPTURE_BUSY_DAYS, busyDays);
+                            session.set(Constants.CONTACT_CAPTURE_BUSY_DAYS, busyDays);
+                        } catch (e) {
+                            log().warn(
+                                `getAvailability failed, continuing without busy days: ${(e as Error).message}`,
+                            );
+                        }
                     }
                 }
             }

--- a/src/strategies/__test__/FormResponseStrategy.test.ts
+++ b/src/strategies/__test__/FormResponseStrategy.test.ts
@@ -229,5 +229,21 @@ describe(`${FormResponseStrategy.name}`, () => {
             expect(threw, threw && threw.stack).to.be.undefined;
             expect(context.session.get(Constants.CONTACT_CAPTURE_BUSY_DAYS)).to.not.exist;
         });
+
+        it("does not throw when getJobType rejects, and skips the availability augmentation", async () => {
+            crmService.getJobType.rejects(new Error("classifier down"));
+            context = buildContext(true); // augmentation branch: getJobType is called
+            const strategy = new FormResponseStrategy();
+
+            let threw: Error | undefined;
+            try {
+                await strategy.getResponse(handler, request, context);
+            } catch (e) {
+                threw = e as Error;
+            }
+            expect(threw, threw && threw.stack).to.be.undefined;
+            // getJobType failed, so no jobType-based availability refetch happened.
+            expect(crmService.getAvailability).to.not.have.been.called;
+        });
     });
 });

--- a/src/strategies/__test__/FormResponseStrategy.test.ts
+++ b/src/strategies/__test__/FormResponseStrategy.test.ts
@@ -1,8 +1,9 @@
 /*! Copyright (c) 2026, XAPP AI */
 import * as chai from "chai";
+import * as sinon from "sinon";
 import * as sinonChai from "sinon-chai";
 
-import { Content, Context, Handler, IntentRequest } from "stentor-models";
+import { Content, Context, CrmService, Handler, IntentRequest } from "stentor-models";
 import { ContextBuilder } from "stentor-context";
 import { IntentRequestBuilder } from "stentor-request";
 
@@ -120,6 +121,113 @@ describe(`${FormResponseStrategy.name}`, () => {
                 threw = e as Error;
             }
             expect(threw, threw && threw.stack).to.be.undefined;
+        });
+    });
+
+    // #663: the widget's availability settings (forceAvailabilityClass / jobTypeClasses) must reach
+    // the CRM's job-type and availability calls, and a CRM rejection must not throw.
+    describe("when a CRM service is configured and the handler carries availabilitySettings", () => {
+        const settings = {
+            forceAvailabilityClass: "drain-emergency",
+            defaultAvailabilityClass: "standard",
+            jobTypeClasses: [{ jobTypeId: "1043", classId: "drain-emergency" }],
+        };
+
+        let crmService: sinon.SinonStubbedInstance<Partial<CrmService>> & {
+            getJobType: sinon.SinonStub;
+            getAvailability: sinon.SinonStub;
+        };
+
+        // seedBusyDays: when set, the first-time branch of addAvailability is skipped and the
+        // getJobType augmentation branch runs instead (that is where the settings/jobType plumbing
+        // lives). Left unset, addAvailability takes the first-time getAvailability branch.
+        const buildContext = (seedBusyDays: boolean): Context => {
+            const data: Record<string, unknown> = {
+                [Constants.CONTACT_CAPTURE_SLOTS]: {},
+                [Constants.CONTACT_CAPTURE_LIST]: {
+                    data: [
+                        {
+                            slotName: "message",
+                            type: "MESSAGE",
+                            collectedValue: "My drain is backed up",
+                        },
+                    ],
+                },
+            };
+            if (seedBusyDays) {
+                data[Constants.CONTACT_CAPTURE_BUSY_DAYS] = {
+                    range: { start: null, end: null },
+                    unavailabilities: [],
+                };
+            }
+            const c = new ContextBuilder().withSessionData({ id: "form-session", data }).build();
+            // No withServices() on ContextBuilder — inject the stub directly.
+            (c.services as { crmService?: Partial<CrmService> }).crmService = crmService;
+            return c;
+        };
+
+        beforeEach(() => {
+            const props: Handler<Content, ContactCaptureData> = {
+                ...PROPS_WITHOUT_CAPTURE,
+                data: {
+                    ...PROPS_WITHOUT_CAPTURE.data,
+                    availabilitySettings: settings,
+                } as unknown as ContactCaptureData,
+            };
+            handler = new ContactCaptureHandler(props);
+            request = new IntentRequestBuilder()
+                .withSlots({})
+                .withIntentId(props.intentId)
+                .build();
+            request.isNewSession = false;
+            request.attributes = {
+                enablePreferredTime: true,
+                data: { step: "contact_info", form: "booking_preferred_time" },
+            };
+
+            crmService = {
+                getJobType: sinon.stub().resolves({ id: "1043", class: "drain-emergency" }),
+                getAvailability: sinon.stub().resolves({ range: { start: null, end: null }, unavailabilities: [] }),
+            } as never;
+        });
+
+        it("passes the handler's availabilitySettings into getJobType as the 3rd arg", async () => {
+            context = buildContext(true);
+            const strategy = new FormResponseStrategy();
+            await strategy.getResponse(handler, request, context);
+
+            expect(crmService.getJobType).to.have.been.calledOnce;
+            const thirdArg = crmService.getJobType.firstCall.args[2];
+            expect(thirdArg).to.deep.include({
+                forceAvailabilityClass: "drain-emergency",
+                jobTypeClasses: settings.jobTypeClasses,
+            });
+        });
+
+        it("passes availabilitySettings through to getAvailability alongside the jobType", async () => {
+            context = buildContext(true);
+            const strategy = new FormResponseStrategy();
+            await strategy.getResponse(handler, request, context);
+
+            expect(crmService.getAvailability).to.have.been.called;
+            const options = crmService.getAvailability.lastCall.args[1];
+            expect(options).to.include({ forceAvailabilityClass: "drain-emergency" });
+            expect(options.jobType).to.deep.equal({ id: "1043", class: "drain-emergency" });
+        });
+
+        it("does not throw when the first-time getAvailability rejects, and stores no busy days", async () => {
+            crmService.getAvailability.rejects(new Error("CRM down"));
+            context = buildContext(false); // first-time branch: getAvailability called directly
+            const strategy = new FormResponseStrategy();
+
+            let threw: Error | undefined;
+            try {
+                await strategy.getResponse(handler, request, context);
+            } catch (e) {
+                threw = e as Error;
+            }
+            expect(threw, threw && threw.stack).to.be.undefined;
+            expect(context.session.get(Constants.CONTACT_CAPTURE_BUSY_DAYS)).to.not.exist;
         });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1553,7 +1553,7 @@ __metadata:
     stentor-context: 1.72.4
     stentor-handler: 1.72.4
     stentor-logger: 1.72.4
-    stentor-models: 1.72.4
+    stentor-models: 1.73.0
     stentor-request: 1.72.4
     stentor-response: 1.72.4
     stentor-service-fetch: 1.72.4
@@ -6481,12 +6481,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stentor-models@npm:1.72.4":
-  version: 1.72.4
-  resolution: "stentor-models@npm:1.72.4"
+"stentor-models@npm:1.73.0":
+  version: 1.73.0
+  resolution: "stentor-models@npm:1.73.0"
   dependencies:
     "@xapp/patterns": 2.0.3
-  checksum: cd4ab9e6d4b0d0003e49c047a92a6e291333727991e8682b2eb184645c99274aa85a74f9aadb274b6093188c44472c636b9da24350054f557d4abed84c32eca4
+  checksum: b00fea6d8f3e05b0ae40bbd0afb48b60789c286b47af409585edb233988f875fd49060cffc89f5cda07420cbee53354b09cb95959abb20da511e9469468b1f14
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #663. Wave 2 of the same-day booking (drain campaign) feature.

The cloud agent implemented this on 2026-07-14 but was **blocked on push permissions** (`github-actions[bot]` denied — the `claude.yml` workflow has `contents: read`) and could not run the suite (no network in the sandbox, and `stentor-models@1.73.0` was unpublished at the time). Redone locally against the now-published `1.73.0`, so this carries a real green test run.

## Context

A campaign booking widget carries its own `availabilitySettings` (deep-merged over the account defaults upstream in stentor-api). This handler is where the CRM availability/job-type calls happen, so those settings have to reach them.

## Changes

- **`package.json`** — `stentor-models` 1.72.4 → 1.73.0 (adds `forceAvailabilityClass`, `jobTypeClasses`, and the optional 3rd `options` param on `CrmService.getJobType`).
- **`FormResponseStrategy.ts`**
  - `addAvailability` passes the in-scope `availabilitySettings` into `getJobType(description, undefined, settings)`, so a widget's `forceAvailabilityClass` / `jobTypeClasses` can influence which class the job resolves to. (The augmentation branch already spread `settings` into `getAvailability`; that is unchanged.)
  - `extras.avalabilityClassId` falls back `jobType?.class ?? forceAvailabilityClass ?? defaultAvailabilityClass`, so a force-classed campaign widget still tags its leads even when there is no AI-derived job type. Kept the existing misspelling — `handler.ts` reads `extras.avalabilityClassId` verbatim; renaming is a separate chore.
  - Both `getAvailability` calls wrapped in try/catch — a CRM rejection no longer throws; `busyDays` stays unset and no `BusyDays` context is added.
- **`data.ts`** — doc comment recording that `availabilitySettings` is the already-merged effective object by the time the handler sees it.

## Tests (mocha + chai + sinon)

New block injecting a stubbed `crmService`:
- `getJobType` receives the handler's `availabilitySettings` as its 3rd arg (augmentation path)
- `settings` **and** the resolved `jobType` both reach `getAvailability`
- a first-time `getAvailability` rejection does not throw and stores no busy days

Written test-first — each failed against the old code for the right reason before the change. **232 passing**, build clean, lint clean on the changed files.

## Not covered

The `avalabilityClassId` fallback is on the lead-send (`sendLead`) path, which these tests do not drive; the fallback itself is a small `??` chain and is exercised by type-checking. Flagging rather than leaving it implied.

## Note for maintainers

The `@claude` workflow (`.github/workflows/claude.yml`) has `contents: read` / `pull-requests: read`, which is why the cloud run could not push. Worth granting write so future cloud PRs on this repo work — happy to send that as a separate PR.