### PR TITLE
Add Claude autonomous workflows

### DIFF
--- a/.github/workflows/auto-address-reviews.yml
+++ b/.github/workflows/auto-address-reviews.yml
@@ -22,7 +22,7 @@ jobs:
     # Only trigger on Claude branches, and not on Claude's own comments
     if: |
       startsWith(github.event.pull_request.head.ref, 'claude/') &&
-      github.event.sender.login != 'claude[bot]' &&
+      github.event.sender.login != 'claude[bot]' && github.event.sender.login != 'claude' &&
       (
         (github.event_name == 'pull_request_review' && github.event.review.state == 'changes_requested') ||
         github.event_name == 'pull_request_review_comment'

--- a/.github/workflows/auto-address-reviews.yml
+++ b/.github/workflows/auto-address-reviews.yml
@@ -17,6 +17,11 @@ permissions:
   pull-requests: write
   issues: write
 
+# Prevent concurrent review handling on the same PR
+concurrency:
+  group: auto-address-reviews-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   address-reviews:
     # Only trigger on Claude branches, and not on Claude's own comments
@@ -51,9 +56,11 @@ jobs:
 
           if [ "$RETRY_COUNT" -ge 5 ]; then
             echo "Already addressed reviews $RETRY_COUNT times, giving up."
-            gh pr comment "$PR_NUM" --body "Review comments have been addressed $RETRY_COUNT times. Stopping auto-address attempts.
+            gh pr comment "$PR_NUM" --body "## Manual Attention Required
 
-@michaelmyers - this PR needs manual review attention."
+Review comments have been addressed **$RETRY_COUNT times**. Auto-address attempts exhausted.
+
+Please review the feedback and address manually."
             echo "should_respond=false" >> $GITHUB_OUTPUT
           else
             NEXT_ATTEMPT=$((RETRY_COUNT + 1))
@@ -121,3 +128,27 @@ jobs:
 
             Be thorough but don't over-engineer. Match the reviewer's expectations.
           claude_args: "--max-turns 30"
+          allowed_tools: |
+            Bash(yarn install)
+            Bash(yarn build)
+            Bash(yarn test)
+            Bash(yarn lint)
+            Bash(yarn format)
+            Bash(npm install)
+            Bash(npm run *)
+            Bash(npm test)
+            Bash(git status)
+            Bash(git diff)
+            Bash(git log)
+            Bash(git add)
+            Bash(git commit)
+            Bash(git push)
+            Bash(git checkout)
+            Bash(git branch)
+            Bash(gh pr *)
+            Bash(gh issue *)
+            Read
+            Write
+            Edit
+            Glob
+            Grep

--- a/.github/workflows/auto-address-reviews.yml
+++ b/.github/workflows/auto-address-reviews.yml
@@ -73,6 +73,8 @@ jobs:
         id: context
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REVIEW_BODY: ${{ github.event.review.body }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           PR_NUM="${{ github.event.pull_request.number }}"
 
@@ -81,26 +83,24 @@ jobs:
             --jq '.[] | select(.in_reply_to_id == null) | "[\(.path):\(.line // .original_line)]: \(.body)"' \
             | head -50)
 
-          # Get the latest review body if this is a review submission
-          if [ "${{ github.event_name }}" == "pull_request_review" ]; then
-            REVIEW_BODY="${{ github.event.review.body }}"
-          else
-            REVIEW_BODY=""
-          fi
-
           echo "comments<<EOF" >> $GITHUB_OUTPUT
           echo "$COMMENTS" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-          echo "review_body<<EOF" >> $GITHUB_OUTPUT
-          echo "$REVIEW_BODY" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          # Get the latest review body if this is a review submission (safe via env)
+          if [ "$EVENT_NAME" == "pull_request_review" ]; then
+            echo "review_body<<EOF" >> $GITHUB_OUTPUT
+            echo "$REVIEW_BODY" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          else
+            echo "review_body=" >> $GITHUB_OUTPUT
+          fi
 
       - name: Ask Claude to address reviews
         if: steps.check.outputs.should_respond == 'true'
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             [auto-address-review attempt ${{ steps.check.outputs.attempt }}]
 

--- a/.github/workflows/auto-address-reviews.yml
+++ b/.github/workflows/auto-address-reviews.yml
@@ -90,15 +90,19 @@ Please review the feedback and address manually."
             --jq '.[] | select(.in_reply_to_id == null) | "[\(.path):\(.line // .original_line)]: \(.body)"' \
             | head -50)
 
-          echo "comments<<EOF" >> $GITHUB_OUTPUT
+          # Use unique delimiters to prevent injection from attacker-controlled review text
+          DELIM_COMMENTS="EOF_COMMENTS_${{ github.run_id }}_$RANDOM"
+          DELIM_REVIEW="EOF_REVIEW_${{ github.run_id }}_$RANDOM"
+
+          echo "comments<<$DELIM_COMMENTS" >> $GITHUB_OUTPUT
           echo "$COMMENTS" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "$DELIM_COMMENTS" >> $GITHUB_OUTPUT
 
           # Get the latest review body if this is a review submission (safe via env)
           if [ "$EVENT_NAME" == "pull_request_review" ]; then
-            echo "review_body<<EOF" >> $GITHUB_OUTPUT
+            echo "review_body<<$DELIM_REVIEW" >> $GITHUB_OUTPUT
             echo "$REVIEW_BODY" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
+            echo "$DELIM_REVIEW" >> $GITHUB_OUTPUT
           else
             echo "review_body=" >> $GITHUB_OUTPUT
           fi
@@ -134,9 +138,6 @@ Please review the feedback and address manually."
             Bash(yarn test)
             Bash(yarn lint)
             Bash(yarn format)
-            Bash(npm install)
-            Bash(npm run *)
-            Bash(npm test)
             Bash(git status)
             Bash(git diff)
             Bash(git log)
@@ -145,8 +146,10 @@ Please review the feedback and address manually."
             Bash(git push)
             Bash(git checkout)
             Bash(git branch)
-            Bash(gh pr *)
-            Bash(gh issue *)
+            Bash(gh pr view)
+            Bash(gh pr diff)
+            Bash(gh pr checks)
+            Bash(gh pr comment)
             Read
             Write
             Edit

--- a/.github/workflows/auto-address-reviews.yml
+++ b/.github/workflows/auto-address-reviews.yml
@@ -1,0 +1,123 @@
+# Auto-address review comments on Claude PRs
+# When review comments are added to a PR created by Claude,
+# this workflow re-invokes Claude to address them.
+#
+# Copy to: .github/workflows/auto-address-reviews.yml in each repo
+
+name: Auto-address reviews
+
+on:
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  address-reviews:
+    # Only trigger on Claude branches, and not on Claude's own comments
+    if: |
+      startsWith(github.event.pull_request.head.ref, 'claude/') &&
+      github.event.sender.login != 'claude[bot]' &&
+      (
+        (github.event_name == 'pull_request_review' && github.event.review.state == 'changes_requested') ||
+        github.event_name == 'pull_request_review_comment'
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if we should respond
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUM="${{ github.event.pull_request.number }}"
+
+          # Don't respond to approvals or simple comments without change requests
+          if [ "${{ github.event_name }}" == "pull_request_review" ]; then
+            STATE="${{ github.event.review.state }}"
+            if [ "$STATE" != "changes_requested" ]; then
+              echo "Review state is '$STATE', not 'changes_requested'. Skipping."
+              echo "should_respond=false" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          fi
+
+          # Check retry count for reviews
+          RETRY_COUNT=$(gh pr view "$PR_NUM" --json comments -q '[.comments[].body | select(contains("[auto-address-review attempt"))] | length')
+
+          if [ "$RETRY_COUNT" -ge 5 ]; then
+            echo "Already addressed reviews $RETRY_COUNT times, giving up."
+            gh pr comment "$PR_NUM" --body "Review comments have been addressed $RETRY_COUNT times. Stopping auto-address attempts.
+
+@michaelmyers - this PR needs manual review attention."
+            echo "should_respond=false" >> $GITHUB_OUTPUT
+          else
+            NEXT_ATTEMPT=$((RETRY_COUNT + 1))
+            echo "should_respond=true" >> $GITHUB_OUTPUT
+            echo "attempt=$NEXT_ATTEMPT" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout repository
+        if: steps.check.outputs.should_respond == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - name: Gather review context
+        if: steps.check.outputs.should_respond == 'true'
+        id: context
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUM="${{ github.event.pull_request.number }}"
+
+          # Get all pending review comments (not yet resolved)
+          COMMENTS=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUM/comments" \
+            --jq '.[] | select(.in_reply_to_id == null) | "[\(.path):\(.line // .original_line)]: \(.body)"' \
+            | head -50)
+
+          # Get the latest review body if this is a review submission
+          if [ "${{ github.event_name }}" == "pull_request_review" ]; then
+            REVIEW_BODY="${{ github.event.review.body }}"
+          else
+            REVIEW_BODY=""
+          fi
+
+          echo "comments<<EOF" >> $GITHUB_OUTPUT
+          echo "$COMMENTS" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+          echo "review_body<<EOF" >> $GITHUB_OUTPUT
+          echo "$REVIEW_BODY" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Ask Claude to address reviews
+        if: steps.check.outputs.should_respond == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            [auto-address-review attempt ${{ steps.check.outputs.attempt }}]
+
+            A reviewer has requested changes on this PR. Please address their feedback.
+
+            Review comments:
+            ${{ steps.context.outputs.review_body }}
+
+            Inline comments:
+            ${{ steps.context.outputs.comments }}
+
+            Instructions:
+            1. Carefully read and understand each piece of feedback
+            2. Make the necessary code changes to address the concerns
+            3. If a comment asks a question, answer it in a PR comment AND make any implied changes
+            4. Commit and push your changes
+            5. Reply to each review comment explaining what you changed
+
+            Be thorough but don't over-engineer. Match the reviewer's expectations.
+          claude_args: "--max-turns 30"

--- a/.github/workflows/auto-fix-ci.yml
+++ b/.github/workflows/auto-fix-ci.yml
@@ -93,14 +93,18 @@ Please review the CI logs and fix manually."
           # Get a summary
           SUMMARY=$(gh run view "$RUN_ID" --json jobs -q '.jobs[] | select(.conclusion == "failure") | "\(.name): \(.conclusion)"' | head -10)
 
-          echo "summary<<EOF" >> $GITHUB_OUTPUT
+          # Use unique delimiters to prevent injection from CI output
+          DELIM_SUMMARY="EOF_SUMMARY_${{ github.run_id }}_$RANDOM"
+          DELIM_LOGS="EOF_LOGS_${{ github.run_id }}_$RANDOM"
+
+          echo "summary<<$DELIM_SUMMARY" >> $GITHUB_OUTPUT
           echo "$SUMMARY" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "$DELIM_SUMMARY" >> $GITHUB_OUTPUT
 
           # Save full logs to output (use delimiter pattern for multiline)
-          echo "logs<<LOGSEOF" >> $GITHUB_OUTPUT
+          echo "logs<<$DELIM_LOGS" >> $GITHUB_OUTPUT
           echo "$LOGS" >> $GITHUB_OUTPUT
-          echo "LOGSEOF" >> $GITHUB_OUTPUT
+          echo "$DELIM_LOGS" >> $GITHUB_OUTPUT
 
       - name: Ask Claude to fix CI
         if: steps.retry.outputs.should_retry == 'true'
@@ -134,9 +138,6 @@ Please review the CI logs and fix manually."
             Bash(yarn test)
             Bash(yarn lint)
             Bash(yarn format)
-            Bash(npm install)
-            Bash(npm run *)
-            Bash(npm test)
             Bash(git status)
             Bash(git diff)
             Bash(git log)
@@ -145,8 +146,10 @@ Please review the CI logs and fix manually."
             Bash(git push)
             Bash(git checkout)
             Bash(git branch)
-            Bash(gh pr *)
-            Bash(gh issue *)
+            Bash(gh pr view)
+            Bash(gh pr diff)
+            Bash(gh pr checks)
+            Bash(gh pr comment)
             Read
             Write
             Edit

--- a/.github/workflows/auto-fix-ci.yml
+++ b/.github/workflows/auto-fix-ci.yml
@@ -17,6 +17,11 @@ permissions:
   issues: write
   actions: read
 
+# Prevent concurrent fix attempts on the same branch
+concurrency:
+  group: auto-fix-ci-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
 jobs:
   fix-ci:
     # Only trigger on failed CI for Claude branches
@@ -54,9 +59,11 @@ jobs:
 
           if [ "$RETRY_COUNT" -ge 3 ]; then
             echo "Already tried $RETRY_COUNT times, giving up. Human intervention needed."
-            gh pr comment "$PR_NUM" --body "CI has failed $RETRY_COUNT times. Stopping auto-fix attempts.
+            gh pr comment "$PR_NUM" --body "## Manual Attention Required
 
-@michaelmyers - this PR needs manual attention."
+CI has failed **$RETRY_COUNT times**. Auto-fix attempts exhausted.
+
+Please review the CI logs and fix manually."
             echo "should_retry=false" >> $GITHUB_OUTPUT
           else
             NEXT_ATTEMPT=$((RETRY_COUNT + 1))
@@ -121,3 +128,27 @@ jobs:
 
             Focus on fixing the actual errors, not suppressing warnings unless that's the root cause.
           claude_args: "--max-turns 30"
+          allowed_tools: |
+            Bash(yarn install)
+            Bash(yarn build)
+            Bash(yarn test)
+            Bash(yarn lint)
+            Bash(yarn format)
+            Bash(npm install)
+            Bash(npm run *)
+            Bash(npm test)
+            Bash(git status)
+            Bash(git diff)
+            Bash(git log)
+            Bash(git add)
+            Bash(git commit)
+            Bash(git push)
+            Bash(git checkout)
+            Bash(git branch)
+            Bash(gh pr *)
+            Bash(gh issue *)
+            Read
+            Write
+            Edit
+            Glob
+            Grep

--- a/.github/workflows/auto-fix-ci.yml
+++ b/.github/workflows/auto-fix-ci.yml
@@ -1,0 +1,120 @@
+# Auto-fix CI failures on Claude PRs
+# When CI fails on a PR that was created by Claude (branch starts with claude/),
+# this workflow re-invokes Claude to fix the issue.
+#
+# Copy to: .github/workflows/auto-fix-ci.yml in each repo
+
+name: Auto-fix CI failures
+
+on:
+  workflow_run:
+    workflows: ["CI", "Tests", "Build", "Lint"]  # Add your CI workflow names here
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  actions: read
+
+jobs:
+  fix-ci:
+    # Only trigger on failed CI for Claude branches
+    if: |
+      github.event.workflow_run.conclusion == 'failure' &&
+      startsWith(github.event.workflow_run.head_branch, 'claude/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get PR for this branch
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="${{ github.event.workflow_run.head_branch }}"
+          PR_NUM=$(gh pr list --repo "${{ github.repository }}" --head "$BRANCH" --json number -q '.[0].number')
+
+          if [ -z "$PR_NUM" ]; then
+            echo "No PR found for branch $BRANCH"
+            exit 0
+          fi
+
+          echo "pr_number=$PR_NUM" >> $GITHUB_OUTPUT
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+
+      - name: Check retry count
+        id: retry
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUM="${{ steps.pr.outputs.pr_number }}"
+
+          # Count how many times we've already tried to fix this PR
+          # Look for our specific comment marker
+          RETRY_COUNT=$(gh pr view "$PR_NUM" --json comments -q '[.comments[].body | select(contains("[auto-fix-ci attempt"))] | length')
+
+          if [ "$RETRY_COUNT" -ge 3 ]; then
+            echo "Already tried $RETRY_COUNT times, giving up. Human intervention needed."
+            gh pr comment "$PR_NUM" --body "CI has failed $RETRY_COUNT times. Stopping auto-fix attempts.
+
+@michaelmyers - this PR needs manual attention."
+            echo "should_retry=false" >> $GITHUB_OUTPUT
+          else
+            NEXT_ATTEMPT=$((RETRY_COUNT + 1))
+            echo "Attempt $NEXT_ATTEMPT of 3"
+            echo "should_retry=true" >> $GITHUB_OUTPUT
+            echo "attempt=$NEXT_ATTEMPT" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout repository
+        if: steps.retry.outputs.should_retry == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.branch }}
+          fetch-depth: 0
+
+      - name: Get failed workflow logs
+        if: steps.retry.outputs.should_retry == 'true'
+        id: logs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RUN_ID="${{ github.event.workflow_run.id }}"
+
+          # Get the failed jobs and their logs (truncated to avoid token limits)
+          LOGS=$(gh run view "$RUN_ID" --log-failed 2>/dev/null | tail -200 || echo "Could not fetch logs")
+
+          # Save to file for the action
+          echo "$LOGS" > /tmp/ci-failure-logs.txt
+
+          # Also get a summary
+          SUMMARY=$(gh run view "$RUN_ID" --json jobs -q '.jobs[] | select(.conclusion == "failure") | "\(.name): \(.conclusion)"' | head -10)
+          echo "summary<<EOF" >> $GITHUB_OUTPUT
+          echo "$SUMMARY" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Ask Claude to fix CI
+        if: steps.retry.outputs.should_retry == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            [auto-fix-ci attempt ${{ steps.retry.outputs.attempt }}]
+
+            CI failed on this PR. Please analyze the failure and fix it.
+
+            Failed jobs:
+            ${{ steps.logs.outputs.summary }}
+
+            Here are the last 200 lines of the failed logs:
+            ```
+            $(cat /tmp/ci-failure-logs.txt)
+            ```
+
+            Instructions:
+            1. Analyze the error messages
+            2. Make the necessary code changes to fix the issues
+            3. Commit and push your fixes
+            4. Do NOT create a new PR - just push to this branch
+
+            Focus on fixing the actual errors, not suppressing warnings unless that's the root cause.
+          claude_args: "--max-turns 30"

--- a/.github/workflows/auto-fix-ci.yml
+++ b/.github/workflows/auto-fix-ci.yml
@@ -29,8 +29,8 @@ jobs:
         id: pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          BRANCH="${{ github.event.workflow_run.head_branch }}"
           PR_NUM=$(gh pr list --repo "${{ github.repository }}" --head "$BRANCH" --json number -q '.[0].number')
 
           if [ -z "$PR_NUM" ]; then
@@ -83,20 +83,23 @@ jobs:
           # Get the failed jobs and their logs (truncated to avoid token limits)
           LOGS=$(gh run view "$RUN_ID" --log-failed 2>/dev/null | tail -200 || echo "Could not fetch logs")
 
-          # Save to file for the action
-          echo "$LOGS" > /tmp/ci-failure-logs.txt
-
-          # Also get a summary
+          # Get a summary
           SUMMARY=$(gh run view "$RUN_ID" --json jobs -q '.jobs[] | select(.conclusion == "failure") | "\(.name): \(.conclusion)"' | head -10)
+
           echo "summary<<EOF" >> $GITHUB_OUTPUT
           echo "$SUMMARY" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+
+          # Save full logs to output (use delimiter pattern for multiline)
+          echo "logs<<LOGSEOF" >> $GITHUB_OUTPUT
+          echo "$LOGS" >> $GITHUB_OUTPUT
+          echo "LOGSEOF" >> $GITHUB_OUTPUT
 
       - name: Ask Claude to fix CI
         if: steps.retry.outputs.should_retry == 'true'
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             [auto-fix-ci attempt ${{ steps.retry.outputs.attempt }}]
 
@@ -107,7 +110,7 @@ jobs:
 
             Here are the last 200 lines of the failed logs:
             ```
-            $(cat /tmp/ci-failure-logs.txt)
+            ${{ steps.logs.outputs.logs }}
             ```
 
             Instructions:

--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -1,0 +1,102 @@
+# Auto-create PR from Claude's implementation
+# When Claude finishes implementing and posts a "Create PR" link, this workflow
+# automatically creates the PR so no human click is needed.
+#
+# Copy to: .github/workflows/auto-pr.yml in each repo
+
+name: Auto-create PR from Claude
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  create-pr:
+    # Only trigger on Claude bot comments that contain the PR creation link
+    if: |
+      github.event.comment.user.login == 'claude[bot]' &&
+      contains(github.event.comment.body, '/compare/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract branch from Claude's comment
+        id: extract
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          # Claude's comment contains a GitHub compare URL like:
+          # https://github.com/owner/repo/compare/main...claude/issue-123-timestamp
+          # Extract the branch name (everything after the last ...)
+
+          BRANCH=$(echo "$COMMENT_BODY" | grep -oP 'compare/[^.]+\.\.\.\K[^)"\s]+' | head -1)
+
+          if [ -z "$BRANCH" ]; then
+            echo "Could not extract branch from comment"
+            exit 1
+          fi
+
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "Found branch: $BRANCH"
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get issue details
+        id: issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ISSUE_NUM="${{ github.event.issue.number }}"
+          TITLE=$(gh issue view "$ISSUE_NUM" --json title -q '.title')
+          echo "title=$TITLE" >> $GITHUB_OUTPUT
+          echo "number=$ISSUE_NUM" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="${{ steps.extract.outputs.branch }}"
+          ISSUE_NUM="${{ steps.issue.outputs.number }}"
+          TITLE="${{ steps.issue.outputs.title }}"
+
+          # Check if PR already exists for this branch
+          EXISTING_PR=$(gh pr list --head "$BRANCH" --json number -q '.[0].number' 2>/dev/null || echo "")
+
+          if [ -n "$EXISTING_PR" ]; then
+            echo "PR #$EXISTING_PR already exists for branch $BRANCH"
+            exit 0
+          fi
+
+          # Create the PR
+          gh pr create \
+            --head "$BRANCH" \
+            --title "$TITLE" \
+            --body "Closes #$ISSUE_NUM
+
+---
+Implemented by Claude Code. Auto-PR created by workflow." \
+            --draft
+
+          echo "PR created successfully"
+
+      - name: Comment on issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ISSUE_NUM="${{ steps.issue.outputs.number }}"
+          BRANCH="${{ steps.extract.outputs.branch }}"
+
+          # Get the PR number we just created
+          PR_NUM=$(gh pr list --head "$BRANCH" --json number -q '.[0].number')
+
+          gh issue comment "$ISSUE_NUM" --body "PR #$PR_NUM auto-created. CI will run automatically.
+
+If CI fails, Claude will attempt to fix it. If reviews are requested, Claude will address them.
+
+You'll only be notified when the PR is ready to merge."

--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -11,9 +11,13 @@ on:
     types: [created]
 
 permissions:
-  contents: write
   pull-requests: write
   issues: write
+
+# Prevent concurrent PR creation for the same issue
+concurrency:
+  group: auto-pr-${{ github.event.issue.number }}
+  cancel-in-progress: false
 
 jobs:
   create-pr:

--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -19,7 +19,7 @@ jobs:
   create-pr:
     # Only trigger on Claude bot comments that contain the PR creation link
     if: |
-      github.event.comment.user.login == 'claude[bot]' &&
+      (github.event.comment.user.login == 'claude[bot]' || github.event.comment.user.login == 'claude') &&
       contains(github.event.comment.body, '/compare/')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,22 +17,58 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  actions: read
   id-token: write
+
+# Prevent concurrent runs on the same issue/PR
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
 
 jobs:
   claude:
-    # Trigger on @claude mention in comments, or @claude in new issue body
+    # Trigger on @claude mention, but not from Claude itself (prevent loops)
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+      github.event.sender.login != 'claude[bot]' &&
+      github.event.sender.login != 'claude' &&
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Run Claude
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--max-turns 50"
+          allowed_tools: |
+            Bash(yarn install)
+            Bash(yarn build)
+            Bash(yarn test)
+            Bash(yarn lint)
+            Bash(yarn format)
+            Bash(npm install)
+            Bash(npm run *)
+            Bash(npm test)
+            Bash(git status)
+            Bash(git diff)
+            Bash(git log)
+            Bash(git add)
+            Bash(git commit)
+            Bash(git push)
+            Bash(git checkout)
+            Bash(git branch)
+            Bash(gh pr *)
+            Bash(gh issue *)
+            Read
+            Write
+            Edit
+            Glob
+            Grep

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,3 +1,8 @@
+# Claude Code Action - Base workflow
+# Responds to @claude mentions in issues and PR comments
+#
+# Copy to: .github/workflows/claude.yml in each repo
+
 name: Claude Code
 
 on:
@@ -7,48 +12,27 @@ on:
     types: [created]
   issues:
     types: [opened, assigned]
-  pull_request_review:
-    types: [submitted]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
 
 jobs:
   claude:
+    # Trigger on @claude mention in comments, or @claude in new issue body
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
     runs-on: ubuntu-latest
-    permissions:
-      contents: write        # allow Claude to push its implementation branch
-      pull-requests: write   # allow Claude to open/update the PR
-      issues: read
-      id-token: write
-      actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 1
+        uses: actions/checkout@v4
 
-      - name: Run Claude Code
-        id: claude
+      - name: Run Claude
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          
-          # This is an optional setting that allows Claude to read CI results on PRs
-          additional_permissions: |
-            actions: read
-
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
-          #
-          # Give the implementer agent the tools it needs to actually build/lint/test its work
-          # before it pushes. The full suite still runs in CI on the pushed branch — this is for
-          # the agent's own verification, so it stops handing back unverified code.
-          claude_args: '--allowed-tools "Bash(yarn install:*),Bash(yarn build:*),Bash(yarn lint:*),Bash(yarn test:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh issue list:*)"'
-
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: "--max-turns 50"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -54,9 +54,6 @@ jobs:
             Bash(yarn test)
             Bash(yarn lint)
             Bash(yarn format)
-            Bash(npm install)
-            Bash(npm run *)
-            Bash(npm test)
             Bash(git status)
             Bash(git diff)
             Bash(git log)
@@ -65,8 +62,15 @@ jobs:
             Bash(git push)
             Bash(git checkout)
             Bash(git branch)
-            Bash(gh pr *)
-            Bash(gh issue *)
+            Bash(gh pr create)
+            Bash(gh pr view)
+            Bash(gh pr diff)
+            Bash(gh pr list)
+            Bash(gh pr checks)
+            Bash(gh pr comment)
+            Bash(gh issue view)
+            Bash(gh issue list)
+            Bash(gh issue comment)
             Read
             Write
             Edit

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,5 +34,5 @@ jobs:
       - name: Run Claude
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--max-turns 50"

--- a/.github/workflows/notify-ready-to-merge.yml
+++ b/.github/workflows/notify-ready-to-merge.yml
@@ -21,6 +21,11 @@ permissions:
   statuses: read
   checks: read
 
+# Prevent concurrent notifications for the same PR
+concurrency:
+  group: notify-ready-${{ github.event.pull_request.number || github.event.check_suite.head_branch || github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
 jobs:
   check-ready:
     # Only check Claude PRs
@@ -114,12 +119,21 @@ jobs:
           REPO="${{ github.repository }}"
           REPO_NAME="${REPO#*/}"
 
+          REVIEW_STATE="${{ steps.ready.outputs.review_decision }}"
+
+          # Build review status message
+          if [ "$REVIEW_STATE" == "APPROVED" ]; then
+            REVIEW_MSG="Approved by reviewer(s)"
+          else
+            REVIEW_MSG="No reviews yet (review recommended)"
+          fi
+
           # Post comment on PR
           gh pr comment "$PR_NUM" --body "## READY TO MERGE
 
 This PR has:
 - All CI checks passing
-- No blocking reviews
+- $REVIEW_MSG
 
 **$REPO_NAME**: [$TITLE]($URL)
 

--- a/.github/workflows/notify-ready-to-merge.yml
+++ b/.github/workflows/notify-ready-to-merge.yml
@@ -1,0 +1,142 @@
+# Notify when Claude PR is ready to merge
+# Triggers when a Claude PR has passing CI and is approved.
+# Posts a comment and can optionally call a webhook.
+#
+# Copy to: .github/workflows/notify-ready-to-merge.yml in each repo
+
+name: Notify ready to merge
+
+on:
+  pull_request_review:
+    types: [submitted]
+  check_suite:
+    types: [completed]
+  workflow_run:
+    workflows: ["CI", "Tests", "Build", "Lint"]  # Add your CI workflow names
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  issues: write
+  statuses: read
+  checks: read
+
+jobs:
+  check-ready:
+    # Only check Claude PRs
+    if: |
+      (github.event_name == 'pull_request_review' && startsWith(github.event.pull_request.head.ref, 'claude/')) ||
+      (github.event_name == 'check_suite' && startsWith(github.event.check_suite.head_branch, 'claude/')) ||
+      (github.event_name == 'workflow_run' && startsWith(github.event.workflow_run.head_branch, 'claude/'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get PR info
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Determine the branch based on event type
+          if [ "${{ github.event_name }}" == "pull_request_review" ]; then
+            BRANCH="${{ github.event.pull_request.head.ref }}"
+            PR_NUM="${{ github.event.pull_request.number }}"
+          elif [ "${{ github.event_name }}" == "check_suite" ]; then
+            BRANCH="${{ github.event.check_suite.head_branch }}"
+            PR_NUM=$(gh pr list --head "$BRANCH" --json number -q '.[0].number')
+          else
+            BRANCH="${{ github.event.workflow_run.head_branch }}"
+            PR_NUM=$(gh pr list --head "$BRANCH" --json number -q '.[0].number')
+          fi
+
+          if [ -z "$PR_NUM" ]; then
+            echo "No PR found for branch $BRANCH"
+            echo "has_pr=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "pr_number=$PR_NUM" >> $GITHUB_OUTPUT
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "has_pr=true" >> $GITHUB_OUTPUT
+
+      - name: Check if PR is ready
+        if: steps.pr.outputs.has_pr == 'true'
+        id: ready
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUM="${{ steps.pr.outputs.pr_number }}"
+
+          # Get PR status
+          PR_DATA=$(gh pr view "$PR_NUM" --json state,isDraft,reviewDecision,statusCheckRollup,title,url)
+
+          STATE=$(echo "$PR_DATA" | jq -r '.state')
+          IS_DRAFT=$(echo "$PR_DATA" | jq -r '.isDraft')
+          REVIEW_DECISION=$(echo "$PR_DATA" | jq -r '.reviewDecision')
+          TITLE=$(echo "$PR_DATA" | jq -r '.title')
+          URL=$(echo "$PR_DATA" | jq -r '.url')
+
+          # Check if all status checks passed
+          CHECKS_PASSED=$(echo "$PR_DATA" | jq '[.statusCheckRollup[]? | select(.conclusion != null)] | all(.conclusion == "SUCCESS" or .conclusion == "NEUTRAL" or .conclusion == "SKIPPED")')
+
+          # Check if already notified
+          ALREADY_NOTIFIED=$(gh pr view "$PR_NUM" --json comments -q '[.comments[].body | select(contains("READY TO MERGE"))] | length')
+
+          echo "state=$STATE" >> $GITHUB_OUTPUT
+          echo "is_draft=$IS_DRAFT" >> $GITHUB_OUTPUT
+          echo "review_decision=$REVIEW_DECISION" >> $GITHUB_OUTPUT
+          echo "checks_passed=$CHECKS_PASSED" >> $GITHUB_OUTPUT
+          echo "already_notified=$ALREADY_NOTIFIED" >> $GITHUB_OUTPUT
+          echo "title=$TITLE" >> $GITHUB_OUTPUT
+          echo "url=$URL" >> $GITHUB_OUTPUT
+
+          # Determine if ready
+          if [ "$STATE" == "OPEN" ] && \
+             [ "$IS_DRAFT" == "false" ] && \
+             [ "$CHECKS_PASSED" == "true" ] && \
+             ([ "$REVIEW_DECISION" == "APPROVED" ] || [ "$REVIEW_DECISION" == "null" ] || [ -z "$REVIEW_DECISION" ]); then
+            echo "is_ready=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_ready=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Notify ready to merge
+        if: steps.ready.outputs.is_ready == 'true' && steps.ready.outputs.already_notified == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUM="${{ steps.pr.outputs.pr_number }}"
+          TITLE="${{ steps.ready.outputs.title }}"
+          URL="${{ steps.ready.outputs.url }}"
+          REPO="${{ github.repository }}"
+          REPO_NAME="${REPO#*/}"
+
+          # Post comment on PR
+          gh pr comment "$PR_NUM" --body "## READY TO MERGE
+
+This PR has:
+- All CI checks passing
+- No blocking reviews
+
+**$REPO_NAME**: [$TITLE]($URL)
+
+Ready for final review and merge."
+
+          # Mark PR as ready for review (remove draft status) if it's a draft
+          if [ "${{ steps.ready.outputs.is_draft }}" == "true" ]; then
+            gh pr ready "$PR_NUM"
+          fi
+
+      - name: Call webhook (optional)
+        if: steps.ready.outputs.is_ready == 'true' && steps.ready.outputs.already_notified == '0'
+        continue-on-error: true
+        run: |
+          # If you have a webhook URL configured, uncomment and use:
+          # curl -X POST "${{ secrets.READY_TO_MERGE_WEBHOOK }}" \
+          #   -H "Content-Type: application/json" \
+          #   -d '{
+          #     "repo": "${{ github.repository }}",
+          #     "pr_number": "${{ steps.pr.outputs.pr_number }}",
+          #     "title": "${{ steps.ready.outputs.title }}",
+          #     "url": "${{ steps.ready.outputs.url }}"
+          #   }'
+
+          echo "PR is ready to merge - webhook would fire here"

--- a/.github/workflows/notify-ready-to-merge.yml
+++ b/.github/workflows/notify-ready-to-merge.yml
@@ -34,16 +34,21 @@ jobs:
         id: pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          CHECK_SUITE_BRANCH: ${{ github.event.check_suite.head_branch }}
+          WORKFLOW_RUN_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          # Determine the branch based on event type
-          if [ "${{ github.event_name }}" == "pull_request_review" ]; then
-            BRANCH="${{ github.event.pull_request.head.ref }}"
-            PR_NUM="${{ github.event.pull_request.number }}"
-          elif [ "${{ github.event_name }}" == "check_suite" ]; then
-            BRANCH="${{ github.event.check_suite.head_branch }}"
+          # Determine the branch based on event type (using env vars to avoid injection)
+          if [ "$EVENT_NAME" == "pull_request_review" ]; then
+            BRANCH="$PR_HEAD_REF"
+            PR_NUM="$PR_NUMBER"
+          elif [ "$EVENT_NAME" == "check_suite" ]; then
+            BRANCH="$CHECK_SUITE_BRANCH"
             PR_NUM=$(gh pr list --head "$BRANCH" --json number -q '.[0].number')
           else
-            BRANCH="${{ github.event.workflow_run.head_branch }}"
+            BRANCH="$WORKFLOW_RUN_BRANCH"
             PR_NUM=$(gh pr list --head "$BRANCH" --json number -q '.[0].number')
           fi
 


### PR DESCRIPTION
## Summary

Adds GitHub Actions workflows for fully autonomous Claude operation:

- **auto-pr.yml**: Auto-creates PR when Claude posts "Create PR" link (no button click needed)
- **auto-fix-ci.yml**: Re-invokes Claude when CI fails on `claude/*` branches (up to 3 attempts)
- **auto-address-reviews.yml**: Re-invokes Claude when reviews request changes (up to 5 attempts)
- **notify-ready-to-merge.yml**: Posts "READY TO MERGE" comment when CI passes and PR is approved

This enables a flow where you create an issue with `@claude`, and you only see it again when it's ready to merge.

## Test plan

- [ ] Verify ANTHROPIC_API_KEY is in repo secrets
- [ ] Create a test issue with `@claude` tag
- [ ] Confirm PR is auto-created
- [ ] Confirm CI failures trigger auto-fix
- [ ] Confirm ready-to-merge notification fires

---
🤖 Created with [Claude Code](https://claude.ai/code)