### PR TITLE
feat: add CostGuide external booking handoff support

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -102,6 +102,49 @@ export interface ContactCaptureData extends QuestionAnsweringData, Pick<FormResp
      * campaign widget's forceAvailabilityClass / jobTypeClasses layered over the account defaults.
      */
     availabilitySettings?: CrmServiceAvailabilitySettings;
+    /**
+     * Hands the visitor off to a third-party booking widget after the lead is captured.
+     *
+     * When enabled, the form gains a terminal handoff step that mounts the partner's booking widget.
+     * The lead is still submitted exactly once to our system; the partner widget handles its own
+     * submission separately.
+     */
+    externalBooking?: {
+        /**
+         * Whether external booking handoff is enabled.
+         */
+        enabled?: boolean;
+        /**
+         * Provider key. Only "costguide" is supported today.
+         */
+        provider: "costguide";
+        /**
+         * Name of the form step that hosts the handoff widget.
+         * @default "book_appointment"
+         */
+        stepName?: string;
+        /**
+         * Partner-issued advertiser ID.
+         */
+        advertiserId: number;
+        /**
+         * Partner-issued campaign ID.
+         */
+        campaignId: string;
+        /**
+         * Partner-issued campaign key.
+         */
+        campaignKey: string;
+        /**
+         * Maps our collected service/job-type id to the partner's trade string.
+         * @example { "roofing": "Roofing - Asphalt Install or Replace" }
+         */
+        tradeMap?: Record<string, string>;
+        /**
+         * Used when the collected service has no tradeMap entry.
+         */
+        defaultTrade?: string;
+    };
 }
 
 export interface ContactCaptureBlueprint

--- a/src/strategies/FormResponseStrategy.ts
+++ b/src/strategies/FormResponseStrategy.ts
@@ -24,6 +24,7 @@ import { ContactCaptureHandler } from "../handler";
 
 import { ResponseStrategy } from "./ResponseStrategy";
 import { getFormResponse, getStepFromData } from "./utils/forms";
+import { buildCostGuideConfig, FormResultData } from "./utils/externalBooking";
 
 /**
  * Action response data object
@@ -270,6 +271,30 @@ export class FormResponseStrategy implements ResponseStrategy {
         // context.session.set(Constants.CONTACT_CAPTURE_SENT, leadSendResult.success);
 
         context.session.set(Constants.CONTACT_CAPTURE_EXISTING_REF_ID, leadSendResult.id);
+
+        // External booking handoff: return FORM_STEP_UPDATE with visitor config for the partner widget
+        const externalBooking = handler.data?.externalBooking;
+        if (externalBooking?.enabled && leadSendResult.success) {
+            const formData = request.attributes?.data as FormActionResponseData | undefined;
+            const visitorConfig = buildCostGuideConfig(formData?.result as FormResultData, externalBooking);
+            if (visitorConfig) {
+                const stepName = externalBooking.stepName || "book_appointment";
+                log().info(`External booking handoff: advancing to ${stepName}`);
+                return {
+                    displays: [
+                        {
+                            type: "FORM_STEP_UPDATE",
+                            step: stepName,
+                            externalWidget: {
+                                config: visitorConfig,
+                            },
+                        },
+                    ],
+                };
+            }
+            // Trade unresolvable — fall through to normal (no handoff)
+            log().warn("External booking enabled but trade unresolvable; skipping handoff");
+        }
 
         // form widget - no response
         response = {};

--- a/src/strategies/utils/__test__/externalBooking.test.ts
+++ b/src/strategies/utils/__test__/externalBooking.test.ts
@@ -1,0 +1,260 @@
+/*! Copyright (c) 2024, XAPP AI */
+import { expect } from "chai";
+
+import {
+    splitName,
+    extractZipFromAddress,
+    normalizePhone,
+    resolveTrade,
+    buildCostGuideConfig,
+} from "../externalBooking";
+
+describe("externalBooking utilities", () => {
+    describe("splitName", () => {
+        it("splits 'Jane Doe' into Jane/Doe", () => {
+            const result = splitName("Jane Doe");
+            expect(result).to.deep.equal({ firstName: "Jane", lastName: "Doe" });
+        });
+
+        it("splits 'Mary Anne Van Der Berg' into Mary/Anne Van Der Berg", () => {
+            const result = splitName("Mary Anne Van Der Berg");
+            expect(result).to.deep.equal({ firstName: "Mary", lastName: "Anne Van Der Berg" });
+        });
+
+        it("handles single-token name 'Cher'", () => {
+            const result = splitName("Cher");
+            expect(result).to.deep.equal({ firstName: "Cher", lastName: "" });
+        });
+
+        it("handles empty string", () => {
+            const result = splitName("");
+            expect(result).to.deep.equal({ firstName: "", lastName: "" });
+        });
+
+        it("handles whitespace-only string", () => {
+            const result = splitName("   ");
+            expect(result).to.deep.equal({ firstName: "", lastName: "" });
+        });
+
+        it("trims leading/trailing whitespace", () => {
+            const result = splitName("  Jane Doe  ");
+            expect(result).to.deep.equal({ firstName: "Jane", lastName: "Doe" });
+        });
+    });
+
+    describe("extractZipFromAddress", () => {
+        it("extracts 5-digit zip from address", () => {
+            expect(extractZipFromAddress("123 Main St, Springfield, IL 62701")).to.equal("62701");
+        });
+
+        it("extracts zip with +4 extension", () => {
+            expect(extractZipFromAddress("123 Main St, Springfield, IL 62701-1234")).to.equal("62701");
+        });
+
+        it("returns undefined when no zip found", () => {
+            expect(extractZipFromAddress("123 Main St, Springfield, IL")).to.be.undefined;
+        });
+
+        it("returns undefined for empty string", () => {
+            expect(extractZipFromAddress("")).to.be.undefined;
+        });
+
+        it("handles zip at end of address", () => {
+            expect(extractZipFromAddress("123 Any St. 17002")).to.equal("17002");
+        });
+    });
+
+    describe("normalizePhone", () => {
+        it("formats 10-digit phone as NNN-NNN-NNNN", () => {
+            expect(normalizePhone("5550001234")).to.equal("555-000-1234");
+        });
+
+        it("formats phone with existing formatting", () => {
+            expect(normalizePhone("(555) 000-1234")).to.equal("555-000-1234");
+        });
+
+        it("passes through already-formatted phone", () => {
+            expect(normalizePhone("555-000-1234")).to.equal("555-000-1234");
+        });
+
+        it("passes through international phone unchanged", () => {
+            expect(normalizePhone("+1-555-000-1234")).to.equal("+1-555-000-1234");
+        });
+
+        it("passes through short phone unchanged", () => {
+            expect(normalizePhone("5551234")).to.equal("5551234");
+        });
+
+        it("returns empty string for empty input", () => {
+            expect(normalizePhone("")).to.equal("");
+        });
+    });
+
+    describe("resolveTrade", () => {
+        const tradeMap = {
+            roofing: "Roofing - Asphalt Install or Replace",
+            windows: "Windows - Replace 6-9 Windows",
+        };
+
+        it("resolves from tradeMap when service matches", () => {
+            expect(resolveTrade("roofing", tradeMap, "Default Trade")).to.equal("Roofing - Asphalt Install or Replace");
+        });
+
+        it("falls back to defaultTrade when service not in map", () => {
+            expect(resolveTrade("plumbing", tradeMap, "Default Trade")).to.equal("Default Trade");
+        });
+
+        it("returns undefined when neither resolves", () => {
+            expect(resolveTrade("plumbing", tradeMap, undefined)).to.be.undefined;
+        });
+
+        it("returns undefined when service is undefined", () => {
+            expect(resolveTrade(undefined, tradeMap, undefined)).to.be.undefined;
+        });
+
+        it("uses defaultTrade when tradeMap is undefined", () => {
+            expect(resolveTrade("anything", undefined, "Default Trade")).to.equal("Default Trade");
+        });
+    });
+
+    describe("buildCostGuideConfig", () => {
+        const baseExternalBooking = {
+            enabled: true,
+            provider: "costguide" as const,
+            advertiserId: 4944,
+            campaignId: "6a283d45eddcf",
+            campaignKey: "6YGTmNKxtjMDVkWPLwgC",
+            tradeMap: {
+                roofing: "Roofing - Asphalt Install or Replace",
+            },
+            defaultTrade: "General",
+        };
+
+        it("builds config with explicit first_name/last_name", () => {
+            const result = buildCostGuideConfig(
+                {
+                    first_name: "Jane",
+                    last_name: "Doe",
+                    email: "jane@example.com",
+                    phone: "5550001234",
+                    address: "123 Any St.",
+                    zip: "17002",
+                    service: "roofing",
+                },
+                baseExternalBooking
+            );
+
+            expect(result).to.deep.equal({
+                firstName: "Jane",
+                lastName: "Doe",
+                address: "123 Any St.",
+                zipCode: "17002",
+                email: "jane@example.com",
+                phone: "555-000-1234",
+                trade: "Roofing - Asphalt Install or Replace",
+                advertiserId: 4944,
+                campaignId: "6a283d45eddcf",
+                campaignKey: "6YGTmNKxtjMDVkWPLwgC",
+                hideNoMatch: "yes",
+                limit: 1,
+            });
+        });
+
+        it("splits full_name when first_name/last_name not provided", () => {
+            const result = buildCostGuideConfig(
+                {
+                    full_name: "Jane Doe",
+                    email: "jane@example.com",
+                    service: "roofing",
+                },
+                baseExternalBooking
+            );
+
+            expect(result?.firstName).to.equal("Jane");
+            expect(result?.lastName).to.equal("Doe");
+        });
+
+        it("prefers first_name/last_name over full_name", () => {
+            const result = buildCostGuideConfig(
+                {
+                    full_name: "Wrong Name",
+                    first_name: "Jane",
+                    last_name: "Doe",
+                    service: "roofing",
+                },
+                baseExternalBooking
+            );
+
+            expect(result?.firstName).to.equal("Jane");
+            expect(result?.lastName).to.equal("Doe");
+        });
+
+        it("extracts zip from address when zip/zip_code not provided", () => {
+            const result = buildCostGuideConfig(
+                {
+                    full_name: "Jane Doe",
+                    address: "123 Main St, City, ST 17002",
+                    service: "roofing",
+                },
+                baseExternalBooking
+            );
+
+            expect(result?.zipCode).to.equal("17002");
+        });
+
+        it("prefers zip over zip_code over extracted", () => {
+            const result = buildCostGuideConfig(
+                {
+                    full_name: "Jane Doe",
+                    zip: "11111",
+                    zip_code: "22222",
+                    address: "123 Main St 33333",
+                    service: "roofing",
+                },
+                baseExternalBooking
+            );
+
+            expect(result?.zipCode).to.equal("11111");
+        });
+
+        it("uses defaultTrade when service not in tradeMap", () => {
+            const result = buildCostGuideConfig(
+                {
+                    full_name: "Jane Doe",
+                    service: "plumbing",
+                },
+                baseExternalBooking
+            );
+
+            expect(result?.trade).to.equal("General");
+        });
+
+        it("returns undefined when trade cannot be resolved", () => {
+            const result = buildCostGuideConfig(
+                {
+                    full_name: "Jane Doe",
+                    service: "plumbing",
+                },
+                {
+                    ...baseExternalBooking,
+                    defaultTrade: undefined,
+                }
+            );
+
+            expect(result).to.be.undefined;
+        });
+
+        it("normalizes 10-digit phone", () => {
+            const result = buildCostGuideConfig(
+                {
+                    full_name: "Jane Doe",
+                    phone: "(555) 000-1234",
+                    service: "roofing",
+                },
+                baseExternalBooking
+            );
+
+            expect(result?.phone).to.equal("555-000-1234");
+        });
+    });
+});

--- a/src/strategies/utils/externalBooking.ts
+++ b/src/strategies/utils/externalBooking.ts
@@ -1,0 +1,196 @@
+/*! Copyright (c) 2024, XAPP AI */
+
+import type { ContactCaptureData } from "../../data";
+
+/**
+ * Visitor data collected from the form submission.
+ */
+export interface FormResultData {
+    full_name?: string;
+    first_name?: string;
+    last_name?: string;
+    phone?: string;
+    email?: string;
+    zip?: string;
+    zip_code?: string;
+    address?: string;
+    service?: string;
+    [key: string]: string | undefined;
+}
+
+/**
+ * CostGuide visitor config payload.
+ */
+export interface CostGuideVisitorConfig {
+    firstName: string;
+    lastName: string;
+    address?: string;
+    zipCode?: string;
+    email?: string;
+    phone?: string;
+    trade: string;
+    advertiserId: number;
+    campaignId: string;
+    campaignKey: string;
+    hideNoMatch: "yes";
+    limit: 1;
+}
+
+/**
+ * Splits a full name into first and last name.
+ * - Single-token names put the token in firstName, lastName empty.
+ * - Multi-token names split on the first whitespace; remainder becomes lastName.
+ *
+ * @example splitName("Jane Doe") => { firstName: "Jane", lastName: "Doe" }
+ * @example splitName("Mary Anne Van Der Berg") => { firstName: "Mary", lastName: "Anne Van Der Berg" }
+ * @example splitName("Cher") => { firstName: "Cher", lastName: "" }
+ */
+export function splitName(fullName: string): { firstName: string; lastName: string } {
+    const trimmed = (fullName || "").trim();
+    if (!trimmed) {
+        return { firstName: "", lastName: "" };
+    }
+
+    const spaceIndex = trimmed.indexOf(" ");
+    if (spaceIndex === -1) {
+        return { firstName: trimmed, lastName: "" };
+    }
+
+    return {
+        firstName: trimmed.slice(0, spaceIndex),
+        lastName: trimmed.slice(spaceIndex + 1),
+    };
+}
+
+/**
+ * Extracts a US zip code from an address string.
+ * Matches 5-digit zip codes optionally followed by -XXXX.
+ */
+export function extractZipFromAddress(address: string): string | undefined {
+    if (!address) return undefined;
+
+    // Match 5-digit zip, optionally followed by -XXXX
+    const match = address.match(/\b(\d{5})(?:-\d{4})?\b/);
+    return match ? match[1] : undefined;
+}
+
+/**
+ * Normalizes a phone number to NNN-NNN-NNNN format if it's 10 digits.
+ * Otherwise returns the phone as-is.
+ */
+export function normalizePhone(phone: string): string {
+    if (!phone) return "";
+
+    // Extract just the digits
+    const digits = phone.replace(/\D/g, "");
+
+    // If exactly 10 digits, format as NNN-NNN-NNNN
+    if (digits.length === 10) {
+        return `${digits.slice(0, 3)}-${digits.slice(3, 6)}-${digits.slice(6)}`;
+    }
+
+    // Otherwise return as-is (international, already formatted, etc.)
+    return phone;
+}
+
+/**
+ * Resolves the trade string from the collected service using the tradeMap or defaultTrade.
+ * Returns undefined if neither resolves (caller should omit handoff entirely).
+ */
+export function resolveTrade(
+    service: string | undefined,
+    tradeMap: Record<string, string> | undefined,
+    defaultTrade: string | undefined
+): string | undefined {
+    if (service && tradeMap && tradeMap[service]) {
+        return tradeMap[service];
+    }
+    return defaultTrade;
+}
+
+/**
+ * Builds the CostGuide visitor config payload from form submission data.
+ * Returns undefined if trade cannot be resolved (handoff should be omitted).
+ */
+export function buildCostGuideConfig(
+    result: FormResultData,
+    externalBooking: NonNullable<ContactCaptureData["externalBooking"]>
+): CostGuideVisitorConfig | undefined {
+    // Resolve trade first - if unresolvable, return undefined
+    const trade = resolveTrade(result.service, externalBooking.tradeMap, externalBooking.defaultTrade);
+    if (!trade) {
+        return undefined;
+    }
+
+    // Resolve names: explicit first_name/last_name win over full_name
+    let firstName: string;
+    let lastName: string;
+
+    if (result.first_name || result.last_name) {
+        firstName = result.first_name || "";
+        lastName = result.last_name || "";
+    } else {
+        const split = splitName(result.full_name || "");
+        firstName = split.firstName;
+        lastName = split.lastName;
+    }
+
+    // Resolve zip: zip, zip_code, or extracted from address
+    const zipCode = result.zip || result.zip_code || extractZipFromAddress(result.address || "");
+
+    // Normalize phone
+    const phone = normalizePhone(result.phone || "");
+
+    return {
+        firstName,
+        lastName,
+        address: result.address,
+        zipCode,
+        email: result.email,
+        phone: phone || undefined,
+        trade,
+        advertiserId: externalBooking.advertiserId,
+        campaignId: externalBooking.campaignId,
+        campaignKey: externalBooking.campaignKey,
+        hideNoMatch: "yes",
+        limit: 1,
+    };
+}
+
+/**
+ * Builds the static external widget config for the handoff step.
+ * This goes in the form definition; per-visitor values come from the submit response.
+ */
+export function buildExternalWidgetStepConfig(
+    externalBooking: NonNullable<ContactCaptureData["externalBooking"]>
+): {
+    anchorId: string;
+    scriptSrc: string;
+    configGlobal: string;
+    successCallbackKey: string;
+    cacheBust: boolean;
+    renderTimeoutMs: number;
+    config: {
+        advertiserId: number;
+        campaignId: string;
+        campaignKey: string;
+        hideNoMatch: "yes";
+        limit: 1;
+    };
+} {
+    return {
+        anchorId: "airo-anchor",
+        scriptSrc: "https://form.contractorappointments.com/js/embed-form.js",
+        configGlobal: "airoBookingForm",
+        successCallbackKey: "apptScheduledCallback",
+        cacheBust: true,
+        renderTimeoutMs: 8000, // spike-validated floor - do NOT lower; render measured 111ms-18.7s
+        config: {
+            advertiserId: externalBooking.advertiserId,
+            campaignId: externalBooking.campaignId,
+            campaignKey: externalBooking.campaignKey,
+            hideNoMatch: "yes",
+            limit: 1,
+        },
+    };
+}

--- a/src/strategies/utils/forms.ts
+++ b/src/strategies/utils/forms.ts
@@ -15,6 +15,16 @@ import { capitalize, existsAndNotEmpty } from "stentor-utils";
 
 import { ContactCaptureData, ContactCaptureService, DataDescriptorBase } from "../../data";
 import { isFormDateInput } from "../../guards";
+import { buildExternalWidgetStepConfig } from "./externalBooking";
+
+/**
+ * Extension of FormStep with external widget support.
+ * TODO: Migrate these fields to stentor-models once validated.
+ */
+interface ExternalWidgetFormStep extends FormStep {
+    fullBleed?: boolean;
+    externalWidget?: ReturnType<typeof buildExternalWidgetStepConfig>;
+}
 
 export const CONTACT_METHOD_GROUP = "contact_method";
 export const CONTACT_METHOD_ERROR = "Please provide either a phone number or email address";
@@ -1227,6 +1237,45 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
         contactUsForm.steps = CONTACT_ONLY_STEPS;
     }
 
+    // External booking handoff: replace the terminal thank-you step with a handoff step
+    if (data.externalBooking?.enabled) {
+        const stepName = data.externalBooking.stepName || "book_appointment";
+        const externalWidgetConfig = buildExternalWidgetStepConfig(data.externalBooking);
+
+        // Build the handoff step
+        const handoffStep: ExternalWidgetFormStep = {
+            name: stepName,
+            title: "Choose your appointment",
+            fields: [],
+            fullBleed: true,
+            previousAction: "omit",
+            nextAction: "omit",
+            warnBeforeUnload: true,
+            externalWidget: externalWidgetConfig,
+        };
+
+        // Find and replace the terminal thank-you step
+        const lastStepIndex = contactUsForm.steps.length - 1;
+        if (lastStepIndex >= 0) {
+            const lastStep = contactUsForm.steps[lastStepIndex];
+            // Replace thank_you or Thanks step with handoff
+            if (lastStep.name === "thank_you" || lastStep.name === "Thanks") {
+                contactUsForm.steps[lastStepIndex] = handoffStep as FormStep;
+
+                // Update the header to match
+                const headerIndex = contactUsForm.header.findIndex(
+                    (h) => h.step === lastStep.name
+                );
+                if (headerIndex >= 0) {
+                    contactUsForm.header[headerIndex] = {
+                        step: stepName,
+                        label: "Book",
+                    };
+                }
+            }
+        }
+    }
+
     // look at the headers and apply the overrides
     if (existsAndNotEmpty(props.headerOverrides)) {
         // loop through the header and find the step
@@ -1317,6 +1366,21 @@ function getForm(data: ContactCaptureData, props: FormResponseProps): MultistepF
             }
         }
     });
+
+    // External booking for custom forms: fill in externalWidget on matching step
+    if (data.externalBooking?.enabled) {
+        const stepName = data.externalBooking.stepName || "book_appointment";
+        const externalWidgetConfig = buildExternalWidgetStepConfig(data.externalBooking);
+
+        // Find existing step by name and fill in its externalWidget
+        const existingStep = formDeclaration.steps.find((step) => step.name === stepName) as
+            | ExternalWidgetFormStep
+            | undefined;
+        if (existingStep) {
+            existingStep.externalWidget = externalWidgetConfig;
+            existingStep.fullBleed = true;
+        }
+    }
 
     return formDeclaration;
 }


### PR DESCRIPTION
## Summary
- Add `externalBooking` configuration to `ContactCaptureData` for CostGuide booking widget integration
- Create utility module (`externalBooking.ts`) with functions to map form data to CostGuide visitor config (name splitting, phone normalization, zip extraction, trade resolution)
- Update form generation to add handoff step when externalBooking is enabled
- Update FormResponseStrategy to return FORM_STEP_UPDATE with visitor config after lead submission

Closes #671

## Test plan
- [x] Unit tests added for all utility functions (splitName, extractZipFromAddress, normalizePhone, resolveTrade, buildCostGuideConfig)
- [x] All 263 existing tests pass
- [ ] Manual testing with CostGuide widget integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)