### PR TITLE
feat: preview the next step in the default form's Next button

### DIFF
--- a/src/strategies/utils/__test__/forms.test.ts
+++ b/src/strategies/utils/__test__/forms.test.ts
@@ -4546,4 +4546,68 @@ describe(`#${getContactFormFallback.name}()`, () => {
             expect(selectionField.items[1].label).to.equal("Electrical");
         });
     });
+
+    describe("'Next' button labels", () => {
+        it("previews the contact info step from the service_request step", () => {
+            const form = getContactFormFallback(
+                { capture: SIMPLE_BLUEPRINT },
+                { enablePreferredTime: true },
+            );
+
+            const step = form.steps.find((s) => s.name === "service_request")!;
+            expect(step.nextLabel).to.equal("Next: Contact Info →");
+        });
+
+        it("previews the preferred date step from contact_info when every service requires a date", () => {
+            const form = getContactFormFallback(
+                {
+                    capture: {
+                        data: SIMPLE_BLUEPRINT.data,
+                        serviceOptions: [
+                            { id: "schedule-now", label: "Schedule Now", requiresDate: true },
+                            { id: "schedule-service", label: "Schedule Service", requiresDate: true },
+                        ],
+                    },
+                },
+                { enablePreferredTime: true },
+            );
+
+            const step = form.steps.find((s) => s.name === "contact_info")!;
+            expect(step.nextLabel).to.equal("Next: Preferred Date →");
+        });
+
+        it("previews the review step from contact_info when no service requires a date", () => {
+            const form = getContactFormFallback(
+                {
+                    capture: {
+                        data: SIMPLE_BLUEPRINT.data,
+                        serviceOptions: [
+                            { id: "schedule_maintenance", label: "Schedule Maintenance", requiresDate: false },
+                            { id: "contact_us", label: "Contact Us", requiresDate: false },
+                        ],
+                    },
+                },
+                { enablePreferredTime: true },
+            );
+
+            const step = form.steps.find((s) => s.name === "contact_info")!;
+            expect(step.nextLabel).to.equal("Next: Review →");
+        });
+
+        it("falls back to the default 'Next' label from contact_info when it depends on the selected service", () => {
+            // DEFAULT_SERVICE_CHIP_ITEMS mixes services that do and don't require a date,
+            // so whether preferred_time shows next depends on the visitor's selection.
+            const form = getContactFormFallback({ capture: SIMPLE_BLUEPRINT }, { enablePreferredTime: true });
+
+            const step = form.steps.find((s) => s.name === "contact_info")!;
+            expect(step.nextLabel).to.be.undefined;
+        });
+
+        it("previews the review step from the preferred_time step", () => {
+            const form = getContactFormFallback({ capture: SIMPLE_BLUEPRINT }, { enablePreferredTime: true });
+
+            const step = form.steps.find((s) => s.name === "preferred_time")!;
+            expect(step.nextLabel).to.equal("Next: Review →");
+        });
+    });
 });

--- a/src/strategies/utils/__test__/forms.test.ts
+++ b/src/strategies/utils/__test__/forms.test.ts
@@ -683,9 +683,7 @@ describe(`#${getFormResponse.name}()`, () => {
         });
 
         it("does not throw with enablePreferredTime when capture is missing", () => {
-            expect(() =>
-                getFormResponse(HANDLER_DATA_WITHOUT_CAPTURE, { enablePreferredTime: true }),
-            ).to.not.throw();
+            expect(() => getFormResponse(HANDLER_DATA_WITHOUT_CAPTURE, { enablePreferredTime: true })).to.not.throw();
         });
     });
 });
@@ -1520,10 +1518,7 @@ describe(`#${getContactFormFallback.name}()`, () => {
     });
     describe("when checking confirmation fields", () => {
         it("includes zip confirmation card when zip field is present", () => {
-            const form = getContactFormFallback(
-                { capture: SIMPLE_BLUEPRINT },
-                { enablePreferredTime: true },
-            );
+            const form = getContactFormFallback({ capture: SIMPLE_BLUEPRINT }, { enablePreferredTime: true });
 
             expect(form).to.exist;
             expect(form.steps).to.have.length(5);
@@ -1707,10 +1702,7 @@ describe(`#${getContactFormFallback.name}()`, () => {
         const findStep = (form: MultistepForm, name: string) => form.steps.find((s) => s.name === name);
 
         it("omits preferred_date chip by default (data has no flag)", () => {
-            const form = getContactFormFallback(
-                { capture: SIMPLE_BLUEPRINT },
-                { enablePreferredTime: true },
-            );
+            const form = getContactFormFallback({ capture: SIMPLE_BLUEPRINT }, { enablePreferredTime: true });
 
             expect(form).to.exist;
 
@@ -1722,10 +1714,7 @@ describe(`#${getContactFormFallback.name}()`, () => {
         });
 
         it("makes dateTime mandatory without a mandatoryGroup by default", () => {
-            const form = getContactFormFallback(
-                { capture: SIMPLE_BLUEPRINT },
-                { enablePreferredTime: true },
-            );
+            const form = getContactFormFallback({ capture: SIMPLE_BLUEPRINT }, { enablePreferredTime: true });
 
             const preferredTimeStep = findStep(form, "preferred_time");
             const dateTimeField = preferredTimeStep!.fields.find((field) => field.name === "dateTime");
@@ -1804,10 +1793,7 @@ describe(`#${getContactFormFallback.name}()`, () => {
 
             const preferredTimeStep = findStep(form, "preferred_time");
             const preferredDateField = preferredTimeStep!.fields.find((field) => field.name === "preferred_date");
-            expect(
-                preferredDateField,
-                "explicit undefined on props must not clobber a boolean from data",
-            ).to.exist;
+            expect(preferredDateField, "explicit undefined on props must not clobber a boolean from data").to.exist;
         });
     });
     describe("when passed showFirstAvailableDay (positively-named alias)", () => {
@@ -2135,7 +2121,7 @@ describe(`#${getContactFormFallback.name}()`, () => {
 
                 expect(form).to.exist;
 
-                const preferredTimeStep = form.steps.find(s => s.name === "preferred_time");
+                const preferredTimeStep = form.steps.find((s) => s.name === "preferred_time");
                 expect(preferredTimeStep).to.exist;
 
                 // Check that the condition is properly sanitized
@@ -2169,7 +2155,7 @@ describe(`#${getContactFormFallback.name}()`, () => {
 
                 expect(form).to.exist;
 
-                const preferredTimeStep = form.steps.find(s => s.name === "preferred_time");
+                const preferredTimeStep = form.steps.find((s) => s.name === "preferred_time");
                 expect(preferredTimeStep).to.exist;
                 // Always show preferred time when all services require a date
                 expect(preferredTimeStep.condition).to.equal("true");
@@ -3582,10 +3568,7 @@ describe(`#${getContactFormFallback.name}()`, () => {
 
             describe("edge cases", () => {
                 it("allows very small maxLength value", () => {
-                    const form = getContactFormFallback(
-                        { capture: SIMPLE_BLUEPRINT },
-                        { messageMaxLength: 50 },
-                    );
+                    const form = getContactFormFallback({ capture: SIMPLE_BLUEPRINT }, { messageMaxLength: 50 });
 
                     const contactStep = form.steps[0];
                     const messageField = contactStep.fields.find((field) => field.name === "message");
@@ -3596,10 +3579,7 @@ describe(`#${getContactFormFallback.name}()`, () => {
                 });
 
                 it("allows very large maxLength value", () => {
-                    const form = getContactFormFallback(
-                        { capture: SIMPLE_BLUEPRINT },
-                        { messageMaxLength: 10000 },
-                    );
+                    const form = getContactFormFallback({ capture: SIMPLE_BLUEPRINT }, { messageMaxLength: 10000 });
 
                     const contactStep = form.steps[0];
                     const messageField = contactStep.fields.find((field) => field.name === "message");
@@ -3610,10 +3590,7 @@ describe(`#${getContactFormFallback.name}()`, () => {
                 });
 
                 it("uses default when messageMaxLength is undefined in both data and props", () => {
-                    const form = getContactFormFallback(
-                        { capture: SIMPLE_BLUEPRINT },
-                        {},
-                    );
+                    const form = getContactFormFallback({ capture: SIMPLE_BLUEPRINT }, {});
 
                     const contactStep = form.steps[0];
                     const messageField = contactStep.fields.find((field) => field.name === "message");
@@ -4549,10 +4526,7 @@ describe(`#${getContactFormFallback.name}()`, () => {
 
     describe("'Next' button labels", () => {
         it("previews the contact info step from the service_request step", () => {
-            const form = getContactFormFallback(
-                { capture: SIMPLE_BLUEPRINT },
-                { enablePreferredTime: true },
-            );
+            const form = getContactFormFallback({ capture: SIMPLE_BLUEPRINT }, { enablePreferredTime: true });
 
             const step = form.steps.find((s) => s.name === "service_request")!;
             expect(step.nextLabel).to.equal("Next: Contact Info →");
@@ -4608,6 +4582,19 @@ describe(`#${getContactFormFallback.name}()`, () => {
 
             const step = form.steps.find((s) => s.name === "preferred_time")!;
             expect(step.nextLabel).to.equal("Next: Review →");
+        });
+
+        it("falls back to the default 'Next' label from contact_info when a service area check will be inserted", () => {
+            // When serviceArea.zipCodes is configured, an out_of_service_area step gets
+            // inserted after contact_info, so we can't guarantee which step is actually
+            // next (depends on whether the visitor's zip is in the service area).
+            const form = getContactFormFallback(
+                { capture: BLUEPRINT_WITH_SERVICE_AREA_ZIP_CODES, enablePreferredTime: true },
+                {},
+            );
+
+            const step = form.steps.find((s) => s.name === "contact_info")!;
+            expect(step.nextLabel).to.be.undefined;
         });
     });
 });

--- a/src/strategies/utils/forms.ts
+++ b/src/strategies/utils/forms.ts
@@ -655,8 +655,23 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
     // reliably follows when every service requires a date; when none do, review is
     // next. When it's a mix, whether preferred_time shows depends on the service the
     // visitor picked, so we leave the default "Next" label rather than guess wrong.
+    //
+    // Additionally, when a serviceArea zip check will be inserted, the next step is
+    // no longer guaranteed (visitors outside the service area see the out_of_service_area
+    // interstitial), so we fall back to the default "Next" label in that case too.
+    const hasZipOrAddressField = CONTACT_FIELDS.some((field) => {
+        return (
+            field.name.toLowerCase() === "zip" ||
+            (field.name.toLowerCase() === "address" && (field as FormFieldTextAddressInput).format === "ADDRESS")
+        );
+    });
+    const willInsertServiceAreaCheck = hasZipOrAddressField && existsAndNotEmpty(data?.capture?.serviceArea?.zipCodes);
+
     let contactInfoNextLabel: string | undefined;
-    if (preferredTimeConditional === "true") {
+    if (willInsertServiceAreaCheck) {
+        // Fall back to default "Next" when service area check will be inserted
+        contactInfoNextLabel = undefined;
+    } else if (preferredTimeConditional === "true") {
         contactInfoNextLabel = "Next: Preferred Date →";
     } else if (preferredTimeConditional === "false") {
         contactInfoNextLabel = "Next: Review →";

--- a/src/strategies/utils/forms.ts
+++ b/src/strategies/utils/forms.ts
@@ -651,6 +651,17 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
             .join(" || ");
     }
 
+    // Label for the contact_info step's "Next" button. The preferred_time step only
+    // reliably follows when every service requires a date; when none do, review is
+    // next. When it's a mix, whether preferred_time shows depends on the service the
+    // visitor picked, so we leave the default "Next" label rather than guess wrong.
+    let contactInfoNextLabel: string | undefined;
+    if (preferredTimeConditional === "true") {
+        contactInfoNextLabel = "Next: Preferred Date →";
+    } else if (preferredTimeConditional === "false") {
+        contactInfoNextLabel = "Next: Review →";
+    }
+
     const confirmationFields: FormField[] = [
         {
             name: "confirmation_card0",
@@ -995,6 +1006,7 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
         {
             name: "service_request",
             nextAction: "next",
+            nextLabel: "Next: Contact Info →",
             title: props.firstPageInputType?.toLowerCase() === "dropdown" ? serviceSelectionTitle : undefined,
             fields: firstStepFields,
         },
@@ -1003,10 +1015,12 @@ export function getContactFormFallback(data: ContactCaptureData, props: FormResp
             nextAction: "next",
             title: "Contact Information",
             fields: CONTACT_FIELDS,
+            ...(contactInfoNextLabel && { nextLabel: contactInfoNextLabel }),
         },
         {
             name: "preferred_time",
             nextAction: "submit",
+            nextLabel: "Next: Review →",
             condition: preferredTimeConditional,
             fields: preferredTimeFields,
         },


### PR DESCRIPTION
## Summary
- Sets `nextLabel` on the default (fallback) multistep form's steps so the "Next" button previews what's next (e.g. "Next: Preferred Date →") instead of the generic "Next", matching the guided UX from the issue screenshot.
- `service_request` → "Next: Contact Info →"; `contact_info` → "Next: Preferred Date →" or "Next: Review →" (or default "Next" when it's ambiguous); `preferred_time` → "Next: Review →".
- Added 5 new tests covering each case.

Closes #679

## Test plan
- [x] `yarn lint`
- [x] `yarn build`
- [x] `yarn test` (264 passing)

Generated with [Claude Code](https://claude.ai/code)