### PR TITLE
feat: always send source "thankyoupage" in the CostGuide handoff config

### DIFF
--- a/src/strategies/utils/__test__/externalBooking.test.ts
+++ b/src/strategies/utils/__test__/externalBooking.test.ts
@@ -208,6 +208,7 @@ describe("#buildHandoffStep()", () => {
             campaignKey: "6YGTmNKxtjMDVkWPLwgC",
             hideNoMatch: "yes",
             limit: 1,
+            source: "thankyoupage",
         });
         expect(step.externalWidget.config).to.not.have.property("firstName");
         expect(step.externalWidget.config).to.not.have.property("zipCode");

--- a/src/strategies/utils/externalBooking.ts
+++ b/src/strategies/utils/externalBooking.ts
@@ -187,6 +187,9 @@ export function buildStaticExternalWidget(
             campaignKey: externalBooking.campaignKey,
             hideNoMatch: "yes",
             limit: 1,
+            // Fixed attribution value CostGuide asked us to always send (identifies the
+            // thank-you-page handoff on their side); saves per-advertiser config for them.
+            source: "thankyoupage",
         },
     };
 }


### PR DESCRIPTION
Partner request from CostGuide: hardcode `source: "thankyoupage"` in the config we send their booking embed (it's an attribution value on their side; hardcoding it saves them per-advertiser config work).

## Change
One line in `buildStaticExternalWidget` — added to the static `externalWidget.config` alongside the other fixed values:

```ts
config: {
    advertiserId, campaignId, campaignKey,
    hideNoMatch: "yes",
    limit: 1,
    source: "thankyoupage",   // <-- added
},
```

It's opaque config the handler forwards to the widget, merged under the per-visitor values — no widget/GraphQL change needed. Test updated to assert the new field. **265 passing**, build + lint clean.

## Downstream
semantic-release will publish a new handler version on merge; it reaches production once stentor-api bumps `@xapp/contact-capture-handler` to it and redeploys (normal library→consumer flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)